### PR TITLE
[Attestation] Attestation report bind to data with arbitrary length

### DIFF
--- a/machine/mtrap.c
+++ b/machine/mtrap.c
@@ -183,6 +183,9 @@ send_ipi:
     case SBI_SM_RESUME_ENCLAVE:
       retval = mcall_sm_resume_enclave(regs, arg0);
       break;
+    case SBI_SM_ATTEST_ENCLAVE:
+      retval = mcall_sm_attest_enclave(arg0, arg1, arg2);
+      break;
     case SBI_SM_NOT_IMPLEMENTED:
       retval = mcall_sm_not_implemented(regs, arg0);
       break;

--- a/sm/attest.c
+++ b/sm/attest.c
@@ -1,0 +1,73 @@
+#include "enclave.h"
+#include "crypto.h"
+#include "page.h"
+
+
+int hash_epm(hash_ctx_t* hash_ctx, int level, pte_t* tb, uintptr_t vaddr, int contiguous)
+{
+  pte_t* walk;
+  int i;
+
+  /* iterate over PTEs */
+  for (walk=tb, i=0; walk < tb + (RISCV_PGSIZE/sizeof(pte_t)); walk += 1,i++)
+  {
+    if (*walk == 0) {
+      contiguous = 0;
+      continue;
+    }
+    uintptr_t vpn;
+    if ( level == 3 && i&0x100 )
+      vpn = ((-1 << RISCV_PGLEVEL_BITS) | (i & 0x1ff));
+    else
+      vpn = ((vaddr << RISCV_PGLEVEL_BITS) | (i&0x1ff));
+    /* include the first virtual address of a contiguous range */
+    if (level == 1 && !contiguous)
+    {
+      uintptr_t va_start = vpn << RISCV_PGSHIFT;
+      hash_extend(hash_ctx, &va_start, sizeof(uintptr_t));
+      printm("VA hashed: 0x%lx\n", va_start);
+      contiguous = 1;
+    }
+
+    /* if PTE is leaf, extend hash for the page */
+    uintptr_t phys_addr = (*walk >> PTE_PPN_SHIFT) << RISCV_PGSHIFT;
+    if (level == 1)
+    {
+      hash_extend_page(hash_ctx, (void*)phys_addr);
+      printm("PAGE hashed: 0x%lx (pa: 0x%lx)\n", vpn << RISCV_PGSHIFT, phys_addr); 
+    }
+    /* otherwise, recurse on a lower level */
+    else
+    {
+      contiguous = hash_epm(hash_ctx, 
+          level - 1, 
+          (pte_t*) phys_addr, 
+          vpn, 
+          contiguous);
+    }
+  }
+
+  return contiguous;
+}
+
+enclave_ret_t hash_enclave(struct enclave_t* enclave)
+{
+  enclave_ret_t ret;
+  hash_ctx_t hash_ctx;
+  int ptlevel = (VA_BITS - RISCV_PGSHIFT) / RISCV_PGLEVEL_BITS;
+  int i;
+  hash_init(&hash_ctx);
+
+  hash_epm(&hash_ctx, 
+      ptlevel, 
+      (pte_t*) (enclave->encl_satp << RISCV_PGSHIFT),
+      0, 0);
+  
+  hash_finalize(enclave->hash, &hash_ctx);
+  printm("Final hash:\n");
+  for(i = 0; i<MDSIZE/sizeof(uint64_t); i++)
+  {
+    printm("%lx\n", *((uint64_t*) enclave->hash + i));
+  }
+  return ENCLAVE_SUCCESS;
+}

--- a/sm/attest.c
+++ b/sm/attest.c
@@ -28,7 +28,7 @@ int hash_epm(hash_ctx_t* hash_ctx, int level, pte_t* tb, uintptr_t vaddr, int co
     {
       uintptr_t va_start = vpn << RISCV_PGSHIFT;
       hash_extend(hash_ctx, &va_start, sizeof(uintptr_t));
-      printm("VA hashed: 0x%lx\n", va_start);
+      //printm("VA hashed: 0x%lx\n", va_start);
       contiguous = 1;
     }
 
@@ -37,7 +37,7 @@ int hash_epm(hash_ctx_t* hash_ctx, int level, pte_t* tb, uintptr_t vaddr, int co
     {
       /* if PTE is leaf, extend hash for the page */
       hash_extend_page(hash_ctx, (void*)phys_addr);
-      printm("PAGE hashed: 0x%lx (pa: 0x%lx)\n", vpn << RISCV_PGSHIFT, phys_addr); 
+      //printm("PAGE hashed: 0x%lx (pa: 0x%lx)\n", vpn << RISCV_PGSHIFT, phys_addr); 
     }
     else
     {
@@ -69,21 +69,10 @@ enclave_ret_t hash_enclave(struct enclave_t* enclave)
       0, 0);
 
   hash_finalize(enclave->hash, &hash_ctx);
-  printm("Final hash:\n");
-  for(i = 0; i<MDSIZE/sizeof(uint64_t); i++)
-  {
-    printm("%lx\n", *((uint64_t*) enclave->hash + i));
-  }
-  return ENCLAVE_SUCCESS;
-}
-
-enclave_ret_t sign_enclave(struct enclave_t* enclave)
-{
-  int i;
-  sm_sign(enclave->sign, enclave->hash, MDSIZE);
-  for(i = 0; i<SIGNATURE_SIZE/sizeof(uint64_t); i++)
-  {
-    printm("%lx\n", *((uint64_t*) enclave->sign + i));
-  }
+  //printm("Final hash:\n");
+  //for(i = 0; i<MDSIZE/sizeof(uint64_t); i++)
+  //{
+  //  printm("%lx\n", *((uint64_t*) enclave->hash + i));
+  //}
   return ENCLAVE_SUCCESS;
 }

--- a/sm/attest.c
+++ b/sm/attest.c
@@ -55,22 +55,35 @@ int hash_epm(hash_ctx_t* hash_ctx, int level, pte_t* tb, uintptr_t vaddr, int co
 
 enclave_ret_t hash_enclave(struct enclave_t* enclave)
 {
-  enclave_ret_t ret;
   hash_ctx_t hash_ctx;
   int ptlevel = RISCV_PGLEVEL_TOP;
   int i;
+  
   hash_init(&hash_ctx);
-
+  
+  // TODO: add configuration parameters
+ 
   hash_epm(&hash_ctx, 
       ptlevel, 
       (pte_t*) (enclave->encl_satp << RISCV_PGSHIFT),
       0, 0);
-  
+
   hash_finalize(enclave->hash, &hash_ctx);
   printm("Final hash:\n");
   for(i = 0; i<MDSIZE/sizeof(uint64_t); i++)
   {
     printm("%lx\n", *((uint64_t*) enclave->hash + i));
+  }
+  return ENCLAVE_SUCCESS;
+}
+
+enclave_ret_t sign_enclave(struct enclave_t* enclave)
+{
+  int i;
+  sm_sign(enclave->sign, enclave->hash, MDSIZE);
+  for(i = 0; i<SIGNATURE_SIZE/sizeof(uint64_t); i++)
+  {
+    printm("%lx\n", *((uint64_t*) enclave->sign + i));
   }
   return ENCLAVE_SUCCESS;
 }

--- a/sm/crypto.c
+++ b/sm/crypto.c
@@ -20,3 +20,8 @@ void hash_finalize(void* md, hash_ctx_t* hash_ctx)
 {
   sha3_final(md, hash_ctx);
 }
+
+void sign(void* sign, const void* data, size_t len, const unsigned char* public_key, const unsigned char* private_key)
+{
+  ed25519_sign(sign, data, len, public_key, private_key);
+}

--- a/sm/crypto.c
+++ b/sm/crypto.c
@@ -1,0 +1,22 @@
+#include "crypto.h"
+#include "page.h"
+
+void hash_init(hash_ctx_t* hash_ctx)
+{
+  sha3_init(hash_ctx, MDSIZE);
+}
+
+void hash_extend(hash_ctx_t* hash_ctx, const void* ptr, size_t len)
+{
+  sha3_update(hash_ctx, ptr, len);
+}
+
+void hash_extend_page(hash_ctx_t* hash_ctx, const void* ptr)
+{
+  sha3_update(hash_ctx, ptr, RISCV_PGSIZE);
+}
+
+void hash_finalize(void* md, hash_ctx_t* hash_ctx)
+{
+  sha3_final(md, hash_ctx);
+}

--- a/sm/crypto.h
+++ b/sm/crypto.h
@@ -14,6 +14,11 @@ typedef sha3_ctx_t hash_ctx_t;
 
 typedef unsigned char byte;
 
+extern byte sm_hash[MDSIZE];
+extern byte sm_signature[SIGNATURE_SIZE];
+extern byte sm_public_key[PUBLIC_KEY_SIZE];
+extern byte sm_private_key[PRIVATE_KEY_SIZE];
+
 void hash_init(hash_ctx_t* hash_ctx);
 void hash_extend(hash_ctx_t* hash_ctx, const void* ptr, size_t len);
 void hash_extend_page(hash_ctx_t* hash_ctx, const void* ptr);

--- a/sm/crypto.h
+++ b/sm/crypto.h
@@ -1,15 +1,23 @@
 #ifndef __CRYPTO_H__
 #define __CRYPTO_H__
 
-#include "sha3/sha3.h"
 #include <stdint.h>
+#include "sha3/sha3.h"
+#include "ed25519/ed25519.h"
 
 typedef sha3_ctx_t hash_ctx_t;
 #define MDSIZE  64
+
+#define SIGNATURE_SIZE  64
+#define PRIVATE_KEY_SIZE  32
+#define PUBLIC_KEY_SIZE 32
+
+typedef unsigned char byte;
 
 void hash_init(hash_ctx_t* hash_ctx);
 void hash_extend(hash_ctx_t* hash_ctx, const void* ptr, size_t len);
 void hash_extend_page(hash_ctx_t* hash_ctx, const void* ptr);
 void hash_finalize(void* md, hash_ctx_t* hash_ctx);
 
+void sign(void* sign, const void* data, size_t len, const byte* public_key, const byte* private_key);
 #endif /* crypto.h */

--- a/sm/crypto.h
+++ b/sm/crypto.h
@@ -1,0 +1,15 @@
+#ifndef __CRYPTO_H__
+#define __CRYPTO_H__
+
+#include "sha3/sha3.h"
+#include <stdint.h>
+
+typedef sha3_ctx_t hash_ctx_t;
+#define MDSIZE  64
+
+void hash_init(hash_ctx_t* hash_ctx);
+void hash_extend(hash_ctx_t* hash_ctx, const void* ptr, size_t len);
+void hash_extend_page(hash_ctx_t* hash_ctx, const void* ptr);
+void hash_finalize(void* md, hash_ctx_t* hash_ctx);
+
+#endif /* crypto.h */

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -85,7 +85,7 @@ unsigned long get_host_satp(unsigned int eid)
 
 int copy_word_to_host(uintptr_t* ptr, uintptr_t value)
 {
-  int region_overlap = 0, i;
+  int region_overlap = 0;
   spinlock_lock(&encl_lock);
   region_overlap = detect_region_overlap_atomic((uintptr_t)ptr, sizeof(uintptr_t));
   if(!region_overlap)
@@ -102,9 +102,9 @@ int copy_word_to_host(uintptr_t* ptr, uintptr_t value)
 // Does not do checking of dest!
 int copy_region_from_host(void* source, void* dest, size_t size){
 
-  int region_overlap = 0, i;
+  int region_overlap = 0;
   spinlock_lock(&encl_lock);
-  region_overlap = detect_region_overlap_atomic((uintptr_t) source, sizeof(uintptr_t));
+  region_overlap = detect_region_overlap_atomic((uintptr_t) source, size);
   if(!region_overlap)
     memcpy(dest, source, size);
   spinlock_unlock(&encl_lock);
@@ -113,7 +113,40 @@ int copy_region_from_host(void* source, void* dest, size_t size){
     return ENCLAVE_REGION_OVERLAPS;
   else
     return ENCLAVE_SUCCESS;
-  
+}
+
+/* copies data from enclave, source must be inside EPM */
+int copy_from_enclave(struct enclave_t* enclave, void* dest, void* source, size_t size) {
+  int legal = 0;
+  spinlock_lock(&encl_lock);
+  legal = (source >= pmp_get_addr(enclave->rid)
+      && source + size <= pmp_get_addr(enclave->rid) +
+      pmp_get_size(enclave->rid));
+  if(legal)
+    memcpy(dest, source, size);
+  spinlock_unlock(&encl_lock);
+
+  if(!legal)
+    return ENCLAVE_ILLEGAL_ARGUMENT;
+  else
+    return ENCLAVE_SUCCESS;
+}
+
+/* copies data into enclave, destination must be inside EPM */
+int copy_to_enclave(struct enclave_t* enclave, void* dest, void* source, size_t size) {
+  int legal = 0;
+  spinlock_lock(&encl_lock);
+  legal = (dest >= pmp_get_addr(enclave->rid)
+      && dest + size <= pmp_get_addr(enclave->rid) +
+      pmp_get_size(enclave->rid));
+  if(legal)
+    memcpy(dest, source, size);
+  spinlock_unlock(&encl_lock);
+
+  if(!legal)
+    return ENCLAVE_ILLEGAL_ARGUMENT;
+  else
+    return ENCLAVE_SUCCESS;
 }
 
 int init_enclave_memory(uintptr_t base, uintptr_t size, uintptr_t utbase, uintptr_t utsize)
@@ -181,7 +214,6 @@ enclave_ret_t create_enclave(struct keystone_sbi_create_t create_args)
   spinlock_lock(&encl_lock);
   enclaves[eid].state = FRESH;
   hash_enclave(&enclaves[eid]);
-  sign_enclave(&enclaves[eid]);
   spinlock_unlock(&encl_lock);
  
   copy_word_to_host((uintptr_t*)eidptr, (uintptr_t)eid);
@@ -406,6 +438,59 @@ enclave_ret_t resume_enclave(uintptr_t* host_regs, unsigned int eid)
   pmp_set(enclaves[eid].rid, PMP_ALL_PERM);
   osm_pmp_set(PMP_NO_PERM); 
   pmp_set(enclaves[eid].utrid, PMP_ALL_PERM);
+
+  return ENCLAVE_SUCCESS;
+}
+
+enclave_ret_t attest_enclave(uintptr_t report_ptr, uintptr_t data, uintptr_t size)
+{
+  int attestable;
+  struct report_t report;
+  int ret;
+  unsigned int eid;
+  if(encl_satp_to_eid(read_csr(satp),&eid) < 0)
+    return ENCLAVE_INVALID_ID;
+
+  if (size > ATTEST_DATA_MAXLEN)
+    return ENCLAVE_ILLEGAL_ARGUMENT;
+
+  spinlock_lock(&encl_lock);
+  attestable = TEST_BIT(encl_bitmap, eid)
+    && (enclaves[eid].state >= INITIALIZED);
+  spinlock_unlock(&encl_lock);
+
+  if(!attestable)
+    return ENCLAVE_NOT_INITIALIZED;
+
+  /* copy data to be signed */
+  ret = copy_from_enclave(&enclaves[eid], 
+      report.enclave.data,
+      (void*) get_phys_addr(data),
+      size);
+  report.enclave.data_len = size;
+  
+  if (ret) {
+    return ret;
+  }
+  
+  memset(report.sm.hash, '\0', MDSIZE); // FIXME
+  memcpy(report.sm.public_key, sm_public_key, PUBLIC_KEY_SIZE);
+  memcpy(report.sm.signature, sm_signature, SIGNATURE_SIZE);
+  memcpy(report.enclave.hash, enclaves[eid].hash, MDSIZE);
+  sm_sign(report.enclave.signature,
+      &report.enclave, 
+      sizeof(struct enclave_report_t)
+      - SIGNATURE_SIZE
+      - ATTEST_DATA_MAXLEN + size);
+
+  /* copy report to the enclave */
+  ret = copy_to_enclave(&enclaves[eid],
+      (void*) get_phys_addr(report_ptr),
+      &report,
+      sizeof(struct report_t));
+  if (ret) {
+    return ret;
+  }
 
   return ENCLAVE_SUCCESS;
 }

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -119,7 +119,7 @@ int copy_region_from_host(void* source, void* dest, size_t size){
 int init_enclave_memory(uintptr_t base, uintptr_t size, uintptr_t utbase, uintptr_t utsize)
 {
   int ret;
-  int ptlevel = (VA_BITS - RISCV_PGSHIFT) / RISCV_PGLEVEL_BITS;
+  int ptlevel = RISCV_PGLEVEL_TOP;
   
   // this function does the followings:
   // (1) Traverse the page table to see if any address points to the outside of EPM
@@ -177,6 +177,7 @@ enclave_ret_t create_enclave(struct keystone_sbi_create_t create_args)
   enclaves[eid].enclave_entry = create_args.enclave_entry;
   enclaves[eid].runtime_entry = create_args.runtime_entry;
 
+  /* prepare hash for attestation */
   hash_enclave(&enclaves[eid]);
 
   spinlock_lock(&encl_lock);

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -177,6 +177,8 @@ enclave_ret_t create_enclave(struct keystone_sbi_create_t create_args)
   enclaves[eid].enclave_entry = create_args.enclave_entry;
   enclaves[eid].runtime_entry = create_args.runtime_entry;
 
+  hash_enclave(&enclaves[eid]);
+
   spinlock_lock(&encl_lock);
   enclaves[eid].state = INITIALIZED;
   spinlock_unlock(&encl_lock);

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -177,11 +177,11 @@ enclave_ret_t create_enclave(struct keystone_sbi_create_t create_args)
   enclaves[eid].enclave_entry = create_args.enclave_entry;
   enclaves[eid].runtime_entry = create_args.runtime_entry;
 
-  /* prepare hash for attestation */
-  hash_enclave(&enclaves[eid]);
-
+  /* prepare hash and signature for attestation */
   spinlock_lock(&encl_lock);
-  enclaves[eid].state = INITIALIZED;
+  enclaves[eid].state = FRESH;
+  hash_enclave(&enclaves[eid]);
+  sign_enclave(&enclaves[eid]);
   spinlock_unlock(&encl_lock);
  
   copy_word_to_host((uintptr_t*)eidptr, (uintptr_t)eid);

--- a/sm/enclave.h
+++ b/sm/enclave.h
@@ -17,7 +17,7 @@ typedef enum {
   RUNNING,
 } enclave_state_t;
 
-
+/* enclave metadata */
 struct enclave_t
 {
   unsigned int eid; //enclave id
@@ -26,17 +26,28 @@ struct enclave_t
   unsigned long host_satp; //supervisor satp
   unsigned long encl_satp; // enclave's page table base
   enclave_state_t state; // global state of the enclave
-  unsigned int n_thread;
 
   /* measurement */
-  unsigned char hash[MDSIZE];
+  byte hash[MDSIZE];
+  byte sign[SIGNATURE_SIZE];
 
   /* entry points */
   uintptr_t enclave_entry;
   uintptr_t runtime_entry;
 
   /* enclave execution context */
+  unsigned int n_thread;
   struct thread_state_t threads[MAX_ENCL_THREADS];
+};
+
+/* attestation report */
+struct report_t
+{
+  byte sm_hash[MDSIZE];
+  byte sm_public_key[PUBLIC_KEY_SIZE];
+  byte sm_signature[SIGNATURE_SIZE];
+  byte enclave_hash[MDSIZE];
+  byte enclave_signature[SIGNATURE_SIZE];
 };
 
 int copy_region_from_host(void* source, void* dest, size_t size);
@@ -52,5 +63,5 @@ enclave_ret_t resume_enclave(uintptr_t* regs, unsigned int eid);
 
 /* attestation */
 enclave_ret_t hash_enclave(struct enclave_t* enclave);
-
+enclave_ret_t sign_enclave(struct enclave_t* enclave);
 #endif

--- a/sm/enclave.h
+++ b/sm/enclave.h
@@ -5,7 +5,7 @@
 #include "thread.h"
 #include "keystone-sbi-arg.h"
 #include "sm.h"
-
+#include "crypto.h"
 /* TODO: does not support multithreaded enclave yet */
 #define MAX_ENCL_THREADS 1
 
@@ -28,6 +28,9 @@ struct enclave_t
   enclave_state_t state; // global state of the enclave
   unsigned int n_thread;
 
+  /* measurement */
+  unsigned char hash[MDSIZE];
+
   /* entry points */
   uintptr_t enclave_entry;
   uintptr_t runtime_entry;
@@ -46,5 +49,8 @@ enclave_ret_t run_enclave(uintptr_t* host_regs, unsigned int eid);
 enclave_ret_t exit_enclave(uintptr_t* regs, unsigned long retval);
 enclave_ret_t stop_enclave(uintptr_t* regs, uint64_t request);
 enclave_ret_t resume_enclave(uintptr_t* regs, unsigned int eid);
+
+/* attestation */
+enclave_ret_t hash_enclave(struct enclave_t* enclave);
 
 #endif

--- a/sm/page.c
+++ b/sm/page.c
@@ -25,3 +25,43 @@ int init_encl_pgtable(int level, pte_t* tb, uintptr_t base, uintptr_t size, uint
   }
   return ret;
 }
+
+static uintptr_t pte_ppn(pte_t pte)
+{
+  return pte >> PTE_PPN_SHIFT;
+}
+
+static size_t pt_idx(uintptr_t addr, int level)
+{
+  size_t idx = addr >> (RISCV_PGLEVEL_BITS*level + RISCV_PGSHIFT);
+  return idx & ((1 << RISCV_PGLEVEL_BITS) - 1);
+}
+
+static uintptr_t __ept_walk_internal(pte_t* root_page_table, uintptr_t addr)
+{
+  pte_t* t = root_page_table;
+  int i;
+  for (i = (VA_BITS - RISCV_PGSHIFT) / RISCV_PGLEVEL_BITS - 1; i > 0; i--) {
+    size_t idx = pt_idx(addr, i);
+    if (!(t[idx] & PTE_V))
+      return 0;
+    t = (pte_t*) (pte_ppn(t[idx]) << RISCV_PGSHIFT);
+  }
+  return t[pt_idx(addr, 0)];
+}
+
+static uintptr_t __ept_walk(pte_t* root_page_table, uintptr_t addr)
+{
+  return __ept_walk_internal(root_page_table, addr);
+}
+
+uintptr_t get_phys_addr(uintptr_t addr)
+{
+  pte_t pte;
+  uintptr_t physaddr;
+  pte =  __ept_walk((pte_t*) (read_csr(satp) << RISCV_PGSHIFT), addr);
+  
+  physaddr = pte_ppn(pte) << RISCV_PGSHIFT;
+  physaddr |= addr & (RISCV_PGSIZE - 1);
+  return physaddr;
+}

--- a/sm/page.h
+++ b/sm/page.h
@@ -17,5 +17,5 @@
 #define RISCV_PGLEVEL_TOP ((VA_BITS - RISCV_PGSHIFT)/RISCV_PGLEVEL_BITS)
 
 int init_encl_pgtable(int level, pte_t* pte, uintptr_t base, uintptr_t size, uintptr_t utbase, uintptr_t utsize);
-
+uintptr_t get_phys_addr(uintptr_t vaddr);
 #endif

--- a/sm/page.h
+++ b/sm/page.h
@@ -6,6 +6,16 @@
 #include "vm.h"
 #include "mtrap.h" 
 
+#if __riscv_xlen == 64
+# define RISCV_PGLEVEL_MASK 0x1ff
+# define RISCV_PGTABLE_HIGHEST_BIT 0x100
+#else
+# define RISCV_PGLEVEL_MASK 0x3ff
+# define RISCV_PGTABLE_HIGHEST_BIT 0x300
+#endif
+
+#define RISCV_PGLEVEL_TOP ((VA_BITS - RISCV_PGSHIFT)/RISCV_PGLEVEL_BITS)
+
 int init_encl_pgtable(int level, pte_t* pte, uintptr_t base, uintptr_t size, uintptr_t utbase, uintptr_t utsize);
 
 #endif

--- a/sm/sm-sbi.c
+++ b/sm/sm-sbi.c
@@ -2,7 +2,7 @@
 #include "pmp.h"
 #include "enclave.h"
 #include <errno.h>
-
+#include "page.h"
 
 uintptr_t mcall_sm_create_enclave(uintptr_t create_args)
 {
@@ -53,6 +53,11 @@ uintptr_t mcall_sm_exit_enclave(uintptr_t* encl_regs, unsigned long retval)
 uintptr_t mcall_sm_stop_enclave(uintptr_t* encl_regs, unsigned long request)
 {
   return stop_enclave(encl_regs, (uint64_t)request);
+}
+
+uintptr_t mcall_sm_attest_enclave(uintptr_t report, uintptr_t data, uintptr_t size)
+{
+  return attest_enclave(report, data, size);
 }
 
 uintptr_t mcall_sm_not_implemented(uintptr_t* encl_regs, unsigned long cause)

--- a/sm/sm-sbi.h
+++ b/sm/sm-sbi.h
@@ -16,5 +16,6 @@ uintptr_t mcall_sm_exit_enclave(uintptr_t* regs, unsigned long retval);
 uintptr_t mcall_sm_not_implemented(uintptr_t* regs, unsigned long a0);
 uintptr_t mcall_sm_stop_enclave(uintptr_t* regs, unsigned long request);
 uintptr_t mcall_sm_resume_enclave(uintptr_t* regs, unsigned long eid);
+uintptr_t mcall_sm_attest_enclave(uintptr_t report, uintptr_t data, uintptr_t size);
 
 #endif

--- a/sm/sm.c
+++ b/sm/sm.c
@@ -8,9 +8,10 @@ static int sm_init_done = 0;
 static int sm_region_id = 0, os_region_id = 0;
 static spinlock_t sm_init_lock = SPINLOCK_INIT;
 
-byte sm_signature[SIGNATURE_SIZE];
-byte sm_public_key[PUBLIC_KEY_SIZE];
-byte sm_private_key[PRIVATE_KEY_SIZE];
+byte sm_hash[MDSIZE] = { 0, };
+byte sm_signature[SIGNATURE_SIZE] = { 0, };
+byte sm_public_key[PUBLIC_KEY_SIZE] = { 0, };
+byte sm_private_key[PRIVATE_KEY_SIZE] = { 0, };
 
 /*extern byte sanctum_sm_signature[64];
 extern byte sanctum_dev_public_key[32];

--- a/sm/sm.h
+++ b/sm/sm.h
@@ -1,7 +1,6 @@
 #ifndef sm_h
 #define sm_h
 
-//FIXME: just arbitrary 128MB range
 #include <stdint.h>
 #include "pmp.h"
 #include "sm-sbi.h"
@@ -12,6 +11,7 @@
 
 #define SBI_SM_CREATE_ENCLAVE   101
 #define SBI_SM_DESTROY_ENCLAVE  102
+#define SBI_SM_ATTEST_ENCLAVE   103
 #define SBI_SM_RUN_ENCLAVE      105
 #define SBI_SM_STOP_ENCLAVE     106
 #define SBI_SM_RESUME_ENCLAVE   107
@@ -33,6 +33,7 @@
 #define ENCLAVE_NOT_RUNNING                 (enclave_ret_t)9
 #define ENCLAVE_NOT_RESUMABLE               (enclave_ret_t)10
 #define ENCLAVE_EDGE_CALL_HOST              (enclave_ret_t)11
+#define ENCLAVE_NOT_INITIALIZED             (enclave_ret_t)12
 
 #define PMP_UNKNOWN_ERROR                   -1U
 #define PMP_SUCCESS                         0

--- a/sm/sm.h
+++ b/sm/sm.h
@@ -48,5 +48,10 @@
 
 void sm_init(void);
 
+/* platform specific functions */
+#define ATTESTATION_KEY_LENGTH  64
+void sm_retrieve_pubkey(void* dest);
+void sm_sign(void* sign, const void* data, size_t len);
+
 int osm_pmp_set(uint8_t perm);
 #endif

--- a/sm/sm.mk.in
+++ b/sm/sm.mk.in
@@ -9,6 +9,8 @@ sm_c_srcs = \
   pmp.c \
   enclave.c \
 	page.c \
+	crypto.c \
+	attest.c \
 	aes/aes.c \
   sha3/sha3.c \
   ed25519/keypair.c \


### PR DESCRIPTION
Simple enclave attestation implemented. Version 1.0

(1) Upon creation, enclave measurement is finalized
(2) Upon attestation SBI call, the SM signs the enclave measurement and arbitrary data with SM secret attestation key.
(3) SM also provides SM's measurement, SM public key, and the signature (signed by the device key)
(4) The final report (SM report + Enclave report) is copied into the enclave buffer (later it can send it out to the remote user)