### PR TITLE
Enable all interrupts except the timer (all should be fine now)

### DIFF
--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -322,26 +322,8 @@ enclave_ret_t run_enclave(uintptr_t* host_regs, unsigned int eid)
   // switch to enclave page table
   write_csr(satp, enclaves[eid].encl_satp);
 
-  // We aren't sure what is generating some interrupts, disable for
-  // now. External interrupts
-  clear_csr(mie, MIP_SEIP);
-  clear_csr(mie, MIP_MEIP);
-
-  // Software too
-  clear_csr(mie, MIP_SSIP);
-  clear_csr(mie, MIP_MSIP);
-
-
   // disable timer set by the OS, clear pending interrupts
   clear_csr(mie, MIP_MTIP);
-  clear_csr(mip, MIP_MSIP);
-  clear_csr(mip, MIP_STIP);
-  clear_csr(mip, MIP_SSIP);
-
-  clear_csr(mip, MIP_MTIP);
-  clear_csr(mip, MIP_STIP);
-  clear_csr(mip, MIP_SSIP);
-  clear_csr(mip, MIP_SEIP);
 
   // set PMP
   pmp_set(enclaves[eid].rid, PMP_ALL_PERM);
@@ -384,15 +366,6 @@ enclave_ret_t exit_enclave(uintptr_t* encl_regs, unsigned long retval)
   // enable timer interrupt
   set_csr(mie, MIP_MTIP);
 
-  // We aren't sure what is generating some interrupts, disable for
-  // now. External interrupts
-  set_csr(mie, MIP_SEIP);
-  set_csr(mie, MIP_MEIP);
-
-  // Software too
-  set_csr(mie, MIP_SSIP);
-  set_csr(mie, MIP_MSIP);
-
   // update enclave state
   spinlock_lock(&encl_lock);
   enclaves[eid].n_thread--;
@@ -431,15 +404,6 @@ enclave_ret_t stop_enclave(uintptr_t* encl_regs, uint64_t request)
   write_csr(satp, encl.host_satp);
   set_csr(mie, MIP_MTIP);
 
-  // We aren't sure what is generating some interrupts, disable for
-  // now. External interrupts
-  set_csr(mie, MIP_SEIP);
-  set_csr(mie, MIP_MEIP);
-
-  // Software too
-  set_csr(mie, MIP_SSIP);
-  set_csr(mie, MIP_MSIP);
-
   switch(request) {
     case(STOP_TIMER_INTERRUPT):
       return ENCLAVE_INTERRUPTED;
@@ -472,22 +436,8 @@ enclave_ret_t resume_enclave(uintptr_t* host_regs, unsigned int eid)
   // switch to enclave page table
   write_csr(satp, enclaves[eid].encl_satp);
 
-  // We aren't sure what is generating some interrupts, disable for
-  // now. External interrupts
-  clear_csr(mie, MIP_SEIP);
-  clear_csr(mie, MIP_MEIP);
-
-  // Software too
-  clear_csr(mie, MIP_SSIP);
-  clear_csr(mie, MIP_MSIP);
-
   // disable timer set by the OS
   clear_csr(mie, MIP_MTIP);
-
-  clear_csr(mip, MIP_MTIP);
-  clear_csr(mip, MIP_STIP);
-  clear_csr(mip, MIP_SSIP);
-  clear_csr(mip, MIP_SEIP);
 
   // set PMP
   pmp_set(enclaves[eid].rid, PMP_ALL_PERM);


### PR DESCRIPTION
Now, the security monitor does not have to control the supervisor
interrupts other than the timer interrupt, since the runtime know how to
deal with it.