### PR TITLE
TOR PMP regions support for CMA enclave memory

### DIFF
--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -130,8 +130,8 @@ enclave_ret_t destroy_enclave(eid_t eid)
 
   // 1. clear all the data in the enclave page
   // requires no lock (single runner)
-  void* base = pmp_get_addr(enclaves[eid].rid);
-  size_t size = pmp_get_size(enclaves[eid].rid);
+  void* base = (void*) region_get_addr(enclaves[eid].rid);
+  size_t size = (size_t) region_get_size(enclaves[eid].rid);
   memset((void*) base, 0, size);
 
   // 2. free pmp region
@@ -525,9 +525,9 @@ enclave_ret_t copy_from_enclave(struct enclave_t* enclave,
                                 void* dest, void* source, size_t size) {
   int legal = 0;
   spinlock_lock(&encl_lock);
-  legal = (source >= pmp_get_addr(enclave->rid)
-      && source + size <= pmp_get_addr(enclave->rid) +
-      pmp_get_size(enclave->rid));
+  legal = (source >= (void*) region_get_addr(enclave->rid)
+      && source + size <= (void*) region_get_addr(enclave->rid) +
+      region_get_size(enclave->rid));
   if(legal)
     memcpy(dest, source, size);
   spinlock_unlock(&encl_lock);
@@ -543,9 +543,9 @@ enclave_ret_t copy_to_enclave(struct enclave_t* enclave,
                               void* dest, void* source, size_t size) {
   int legal = 0;
   spinlock_lock(&encl_lock);
-  legal = (dest >= pmp_get_addr(enclave->rid)
-      && dest + size <= pmp_get_addr(enclave->rid) +
-      pmp_get_size(enclave->rid));
+  legal = (dest >= (void*) region_get_addr(enclave->rid)
+      && dest + size <= (void*) region_get_addr(enclave->rid) +
+      region_get_size(enclave->rid));
   if(legal)
     memcpy(dest, source, size);
   spinlock_unlock(&encl_lock);

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -130,8 +130,8 @@ enclave_ret_t destroy_enclave(eid_t eid)
 
   // 1. clear all the data in the enclave page
   // requires no lock (single runner)
-  void* base = (void*) region_get_addr(enclaves[eid].rid);
-  size_t size = (size_t) region_get_size(enclaves[eid].rid);
+  void* base = (void*) pmp_region_get_addr(enclaves[eid].rid);
+  size_t size = (size_t) pmp_region_get_size(enclaves[eid].rid);
   memset((void*) base, 0, size);
 
   // 2. free pmp region
@@ -488,7 +488,7 @@ enclave_ret_t copy_word_to_host(uintptr_t* dest_ptr, uintptr_t value)
 {
   int region_overlap = 0;
   spinlock_lock(&encl_lock);
-  region_overlap = detect_region_overlap_atomic((uintptr_t)dest_ptr,
+  region_overlap = pmp_detect_region_overlap_atomic((uintptr_t)dest_ptr,
                                                 sizeof(uintptr_t));
   if(!region_overlap)
     *dest_ptr = value;
@@ -508,7 +508,7 @@ enclave_ret_t copy_from_host(void* source, void* dest, size_t size){
 
   int region_overlap = 0;
   spinlock_lock(&encl_lock);
-  region_overlap = detect_region_overlap_atomic((uintptr_t) source, size);
+  region_overlap = pmp_detect_region_overlap_atomic((uintptr_t) source, size);
   // TODO: Validate that dest is inside the SM.
   if(!region_overlap)
     memcpy(dest, source, size);
@@ -525,9 +525,9 @@ enclave_ret_t copy_from_enclave(struct enclave_t* enclave,
                                 void* dest, void* source, size_t size) {
   int legal = 0;
   spinlock_lock(&encl_lock);
-  legal = (source >= (void*) region_get_addr(enclave->rid)
-      && source + size <= (void*) region_get_addr(enclave->rid) +
-      region_get_size(enclave->rid));
+  legal = (source >= (void*) pmp_region_get_addr(enclave->rid)
+      && source + size <= (void*) pmp_region_get_addr(enclave->rid) +
+      pmp_region_get_size(enclave->rid));
   if(legal)
     memcpy(dest, source, size);
   spinlock_unlock(&encl_lock);
@@ -543,9 +543,9 @@ enclave_ret_t copy_to_enclave(struct enclave_t* enclave,
                               void* dest, void* source, size_t size) {
   int legal = 0;
   spinlock_lock(&encl_lock);
-  legal = (dest >= (void*) region_get_addr(enclave->rid)
-      && dest + size <= (void*) region_get_addr(enclave->rid) +
-      region_get_size(enclave->rid));
+  legal = (dest >= (void*) pmp_region_get_addr(enclave->rid)
+      && dest + size <= (void*) pmp_region_get_addr(enclave->rid) +
+      pmp_region_get_size(enclave->rid));
   if(legal)
     memcpy(dest, source, size);
   spinlock_unlock(&encl_lock);

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -13,8 +13,6 @@
 
 #define ENCL_MAX  16
 
-
-
 struct enclave_t enclaves[ENCL_MAX];
 #define ENCLAVE_EXISTS(eid) (enclaves[eid].state >= 0)
 
@@ -56,28 +54,28 @@ enclave_ret_t create_enclave(struct keystone_sbi_create_t create_args)
   int i;
   int region_overlap = 0;
 
-  // 1. allocate eid
+  // allocate eid
   ret = ENCLAVE_NO_FREE_RESOURCE;
   if(encl_alloc_eid(&eid) != ENCLAVE_SUCCESS)
     goto error;
 
-  // 2. create a PMP region bound to the enclave
+  // create a PMP region bound to the enclave
   ret = ENCLAVE_PMP_FAILURE;
   if(pmp_region_init_atomic(base, size, PMP_PRI_ANY, &region, 0))
     goto free_encl_idx;
 
-  // 2b. create PMP region for shared memory
+  // create PMP region for shared memory
   if(pmp_region_init_atomic(utbase, utsize, PMP_PRI_BOTTOM, &shared_region, 0))
     goto free_region;
 
-  // 3. set pmp registers for private region (not shared)
+  // set pmp registers for private region (not shared)
   if(pmp_set_global(region, PMP_NO_PERM))
     goto free_shared_region;
 
-  // 4. initialize and verify enclave memory layout.
+  // initialize and verify enclave memory layout.
   init_enclave_memory(base, size, utbase, utsize);
 
-  // 5. initialize enclave metadata
+  // initialize enclave metadata
   enclaves[eid].eid = eid;
   enclaves[eid].rid = region;
   enclaves[eid].utrid = shared_region;

--- a/sm/pmp.h
+++ b/sm/pmp.h
@@ -12,9 +12,9 @@
 #define PMP_N_REG         8 //number of PMP registers
 #define PMP_MAX_N_REGION  16 //maximum number of PMP regions
 
-#define SET_BIT(bitmap, n) (bitmap |= (0x1 << n))
-#define UNSET_BIT(bitmap, n) (bitmap &= ~(0x1 << n))
-#define TEST_BIT(bitmap, n) (bitmap & (0x1 << n))
+#define SET_BIT(bitmap, n) (bitmap |= (0x1 << (n)))
+#define UNSET_BIT(bitmap, n) (bitmap &= ~(0x1 << (n)))
+#define TEST_BIT(bitmap, n) (bitmap & (0x1 << (n)))
 
 enum pmp_priority {
   PMP_PRI_ANY,

--- a/sm/sm.c
+++ b/sm/sm.c
@@ -36,7 +36,7 @@ int osm_pmp_set(uint8_t perm)
 int smm_init()
 {
   int region = -1;
-  int ret = pmp_region_init_atomic(SMM_BASE, SMM_SIZE, PMP_PRI_TOP, &region, 0);
+  int ret = pmp_region_init_atomic(0, SMM_BASE + SMM_SIZE, PMP_PRI_TOP, &region, 0);
   if(ret)
     return -1;
 

--- a/sm/sm.h
+++ b/sm/sm.h
@@ -48,6 +48,7 @@
 #define PMP_REGION_MAX_REACHED              23
 #define PMP_REGION_INVALID                  24
 #define PMP_REGION_OVERLAP                  25
+#define PMP_REGION_IMPOSSIBLE_TOR           26
 
 void sm_init(void);
 


### PR DESCRIPTION
In order to support CMA-allocated enclave memory, the SM is now aware of how to handle TOR PMP regions.
It just finds two sequential empty PMP entries and use them for a TOR region.
SM does not make any intelligent decision, such as merging two continuous memory.
I think it is okay for now since we mostly run a few enclaves.