### PR TITLE
Prepare for SeL4 support

### DIFF
--- a/sm/attest.c
+++ b/sm/attest.c
@@ -20,13 +20,13 @@ int hash_epm(hash_ctx_t* hash_ctx, int level, pte_t* tb, uintptr_t vaddr, int co
       continue;
     }
     uintptr_t vpn;
-    
+
     /* propagate the highest bit of the VA */
     if ( level == RISCV_PGLEVEL_TOP && i & RISCV_PGTABLE_HIGHEST_BIT )
       vpn = ((-1 << RISCV_PGLEVEL_BITS) | (i & RISCV_PGLEVEL_MASK));
     else
       vpn = ((vaddr << RISCV_PGLEVEL_BITS) | (i & RISCV_PGLEVEL_MASK));
-    
+
     /* include the first virtual address of a contiguous range */
     if (level == 1 && !contiguous)
     {
@@ -41,15 +41,15 @@ int hash_epm(hash_ctx_t* hash_ctx, int level, pte_t* tb, uintptr_t vaddr, int co
     {
       /* if PTE is leaf, extend hash for the page */
       hash_extend_page(hash_ctx, (void*)phys_addr);
-      //printm("PAGE hashed: 0x%lx (pa: 0x%lx)\n", vpn << RISCV_PGSHIFT, phys_addr); 
+      //printm("PAGE hashed: 0x%lx (pa: 0x%lx)\n", vpn << RISCV_PGSHIFT, phys_addr);
     }
     else
     {
       /* otherwise, recurse on a lower level */
-      contiguous = hash_epm(hash_ctx, 
-          level - 1, 
-          (pte_t*) phys_addr, 
-          vpn, 
+      contiguous = hash_epm(hash_ctx,
+          level - 1,
+          (pte_t*) phys_addr,
+          vpn,
           contiguous);
     }
   }
@@ -62,15 +62,15 @@ enclave_ret_t hash_enclave(struct enclave_t* enclave)
   hash_ctx_t hash_ctx;
   int ptlevel = RISCV_PGLEVEL_TOP;
   int i;
-  
+
   hash_init(&hash_ctx);
 
   // hash the runtime parameters
-  hash_extend(&hash_ctx, &enclave->params, sizeof(struct runtime_params_t));
+  hash_extend(&hash_ctx, &enclave->params, sizeof(struct runtime_va_params_t));
 
   // hash the epm contents including the virtual addresses
-  hash_epm(&hash_ctx, 
-      ptlevel, 
+  hash_epm(&hash_ctx,
+      ptlevel,
       (pte_t*) (enclave->encl_satp << RISCV_PGSHIFT),
       0, 0);
 

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -22,13 +22,51 @@ extern void save_host_regs(void);
 extern void restore_host_regs(void);
 extern byte dev_public_key[PUBLIC_KEY_SIZE];
 
-/*********************************
+*********************************
  *
  * Enclave SBI functions
  * These are exposed to S-mode via the sm-sbi interface
  *
  *********************************/
 
+static int is_create_args_valid(struct keystone_sbi_create_t* args)
+{
+  uintptr_t epm_start, epm_end;
+
+  // check if physical addresses are valid
+  if (args->epm_region.size > 0)
+    return 0;
+
+  // check if overflow
+  if (args->epm_region.paddr >=
+      args->epm_region.paddr + args->epm_region.size)
+    return 0;
+  if (args->utm_region.paddr >=
+      args->utm_region.paddr + args->utm_region.size)
+    return 0;
+
+  epm_start = args->epm_region.paddr;
+  epm_end = args->epm_region.paddr + args->epm_region.size;
+
+  // check if physical addresses are in the range
+  if (args->runtime_paddr < epm_start ||
+      args->runtime_paddr >= epm_end)
+    return 0;
+  if (args->user_paddr < epm_start ||
+      args->user_paddr >= epm_end)
+    return 0;
+  if (args->free_paddr < epm_start ||
+      args->free_paddr >= epm_end)
+    return 0;
+
+  // check the order of physical addresses
+  if (args->runtime_paddr >= args->user_paddr)
+    return 0;
+  if (args->user_paddr >= args->free_paddr)
+    return 0;
+
+  return 1;
+}
 
 /* This handles creation of a new enclave, based on arguments provided
  * by the untrusted host.
@@ -44,15 +82,26 @@ enclave_ret_t create_enclave(struct keystone_sbi_create_t create_args)
   size_t utsize = create_args.utm_region.size;
   eid_t* eidptr = create_args.eid_pptr;
 
-  /* Runtime parameters */
-  struct runtime_params_t params = create_args.params;
-
   uint8_t perm = 0;
   eid_t eid;
   enclave_ret_t ret;
   int region, shared_region;
   int i;
   int region_overlap = 0;
+
+  /* Runtime parameters */
+  if(!is_create_args_valid(&create_args))
+    return ENCLAVE_ILLEGAL_ARGUMENT;
+
+  /* set va params */
+  struct runtime_va_params_t params = create_args.params;
+  struct runtime_pa_params_t pa_params;
+  pa_params.dram_base = base;
+  pa_params.dram_size = size;
+  pa_params.runtime_base = create_args.runtime_paddr;
+  pa_params.user_base = create_args.user_paddr;
+  pa_params.free_base = create_args.free_paddr;
+
 
   // allocate eid
   ret = ENCLAVE_NO_FREE_RESOURCE;
@@ -84,6 +133,7 @@ enclave_ret_t create_enclave(struct keystone_sbi_create_t create_args)
   enclaves[eid].encl_satp = ((base >> RISCV_PGSHIFT) | SATP_MODE_CHOICE);
   enclaves[eid].n_thread = 0;
   enclaves[eid].params = params;
+  enclaves[eid].pa_params = pa_params;
 
   /* prepare hash and signature for attestation */
   spinlock_lock(&encl_lock);
@@ -145,7 +195,8 @@ enclave_ret_t destroy_enclave(eid_t eid)
   enclaves[eid].host_satp = 0;
   enclaves[eid].encl_satp = 0;
   enclaves[eid].n_thread = 0;
-  enclaves[eid].params = (struct runtime_params_t) {0};
+  enclaves[eid].params = (struct runtime_va_params_t) {0};
+  enclaves[eid].pa_params = (struct runtime_pa_params_t) {0};
 
   // 3. release eid
   encl_free_eid(eid);
@@ -171,7 +222,7 @@ enclave_ret_t run_enclave(uintptr_t* host_regs, eid_t eid)
   }
 
   // Enclave is OK to run, context switch to it
-  return _context_switch_to_enclave(host_regs, eid, 1);
+  return context_switch_to_enclave(host_regs, eid, 1);
 }
 
 enclave_ret_t exit_enclave(uintptr_t* encl_regs, unsigned long retval)
@@ -189,7 +240,7 @@ enclave_ret_t exit_enclave(uintptr_t* encl_regs, unsigned long retval)
   if(!exitable)
     return ENCLAVE_NOT_RUNNING;
 
-  _context_switch_to_host(encl_regs, eid);
+  context_switch_to_host(encl_regs, eid);
 
   // update enclave state
   spinlock_lock(&encl_lock);
@@ -215,7 +266,7 @@ enclave_ret_t stop_enclave(uintptr_t* encl_regs, uint64_t request)
   if(!stoppable)
     return ENCLAVE_NOT_RUNNING;
 
-  _context_switch_to_host(encl_regs, eid);
+  context_switch_to_host(encl_regs, eid);
 
   switch(request) {
   case(STOP_TIMER_INTERRUPT):
@@ -245,7 +296,7 @@ enclave_ret_t resume_enclave(uintptr_t* host_regs, eid_t eid)
   }
 
   // Enclave is OK to resume, context switch to it
-  return _context_switch_to_enclave(host_regs, eid, 0);
+  return context_switch_to_enclave(host_regs, eid, 0);
 }
 
 enclave_ret_t attest_enclave(uintptr_t report_ptr, uintptr_t data, uintptr_t size)
@@ -316,7 +367,7 @@ enclave_ret_t attest_enclave(uintptr_t report_ptr, uintptr_t data, uintptr_t siz
  *
  * Expects that eid has already been valided, and it is OK to run this enclave
 */
-inline enclave_ret_t _context_switch_to_enclave(uintptr_t* regs,
+static inline enclave_ret_t context_switch_to_enclave(uintptr_t* regs,
                                                 eid_t eid,
                                                 int load_parameters){
 
@@ -327,10 +378,25 @@ inline enclave_ret_t _context_switch_to_enclave(uintptr_t* regs,
 
   if(load_parameters){
     // passing parameters for a first run
+    // $mepc: (VA) kernel entry
     write_csr(mepc, (uintptr_t) enclaves[eid].params.runtime_entry);
-    regs[11] = (uintptr_t) enclaves[eid].params.user_entry;
-    regs[12] = (uintptr_t) enclaves[eid].params.untrusted_ptr;
-    regs[13] = (uintptr_t) enclaves[eid].params.untrusted_size;
+    // $sepc: (VA) user entry
+    write_csr(sepc, (uintptr_t) enclaves[eid].params.user_entry);
+    // $a1: (PA) DRAM base,
+    regs[11] = (uintptr_t) enclaves[eid].pa_params.dram_base;
+    // $a2: (PA) DRAM size,
+    regs[12] = (uintptr_t) enclaves[eid].pa_params.dram_size;
+    // $a3: (PA) kernel location,
+    regs[13] = (uintptr_t) enclaves[eid].pa_params.runtime_base;
+    // $a4: (PA) user location,
+    regs[14] = (uintptr_t) enclaves[eid].pa_params.user_base;
+    // $a5: (PA) freemem location,
+    regs[15] = (uintptr_t) enclaves[eid].pa_params.free_base;
+    // $a6: (VA) utm base,
+    regs[16] = (uintptr_t) enclaves[eid].params.untrusted_ptr;
+    // $a7: (size_t) utm size
+    regs[17] = (uintptr_t) enclaves[eid].params.untrusted_size;
+
   }
 
   // switch to enclave page table
@@ -352,8 +418,8 @@ inline enclave_ret_t _context_switch_to_enclave(uintptr_t* regs,
   return ENCLAVE_SUCCESS;
 }
 
-inline void _context_switch_to_host(uintptr_t* encl_regs,
-                                    eid_t eid){
+inline void context_switch_to_host(uintptr_t* encl_regs,
+    eid_t eid){
   // get the running enclave on this SM
   struct enclave_t encl = enclaves[eid];
 
@@ -376,6 +442,8 @@ inline void _context_switch_to_host(uintptr_t* encl_regs,
 }
 
 
+// TODO: This function is externally used.
+// refactoring needed
 /*
  * Init all metadata as needed for keeping track of enclaves
  * Called once by the SM on startup
@@ -390,8 +458,8 @@ void enclave_init_metadata(){
 }
 
 
-enclave_ret_t init_enclave_memory(uintptr_t base, uintptr_t size,
-                                  uintptr_t utbase, uintptr_t utsize)
+static enclave_ret_t init_enclave_memory(uintptr_t base, uintptr_t size,
+    uintptr_t utbase, uintptr_t utsize)
 {
   int ret;
   int ptlevel = RISCV_PGLEVEL_TOP;
@@ -412,7 +480,7 @@ enclave_ret_t init_enclave_memory(uintptr_t base, uintptr_t size,
 }
 
 /* FIXME: this takes O(n), change it to use a hash table */
-enclave_ret_t encl_satp_to_eid(uintptr_t satp, eid_t* eid)
+static enclave_ret_t encl_satp_to_eid(uintptr_t satp, eid_t* eid)
 {
   unsigned int i;
   for(i=0; i<ENCL_MAX; i++)
@@ -425,7 +493,7 @@ enclave_ret_t encl_satp_to_eid(uintptr_t satp, eid_t* eid)
   return ENCLAVE_INVALID_ID;
 }
 /* FIXME: this takes O(n), change it to use a hash table */
-enclave_ret_t host_satp_to_eid(uintptr_t satp, eid_t* eid)
+static enclave_ret_t host_satp_to_eid(uintptr_t satp, eid_t* eid)
 {
   unsigned int i;
   for(i=0; i<ENCL_MAX; i++)
@@ -438,7 +506,7 @@ enclave_ret_t host_satp_to_eid(uintptr_t satp, eid_t* eid)
   return ENCLAVE_INVALID_ID;
 }
 
-enclave_ret_t encl_alloc_eid(eid_t* _eid)
+static enclave_ret_t encl_alloc_eid(eid_t* _eid)
 {
   eid_t eid;
 
@@ -464,7 +532,7 @@ enclave_ret_t encl_alloc_eid(eid_t* _eid)
   }
 }
 
-enclave_ret_t encl_free_eid(eid_t eid)
+static enclave_ret_t encl_free_eid(eid_t eid)
 {
   spinlock_lock(&encl_lock);
   enclaves[eid].state = DESTROYED;
@@ -472,6 +540,8 @@ enclave_ret_t encl_free_eid(eid_t eid)
   return ENCLAVE_SUCCESS;
 }
 
+// TODO: This function is externally used by sm-sbi.c.
+// refactoring needed
 enclave_ret_t get_host_satp(eid_t eid, unsigned long* satp)
 {
   if(!ENCLAVE_EXISTS(eid))
@@ -484,7 +554,7 @@ enclave_ret_t get_host_satp(eid_t eid, unsigned long* satp)
 
 /* Ensures that dest ptr is in host, not in enclave regions
  */
-enclave_ret_t copy_word_to_host(uintptr_t* dest_ptr, uintptr_t value)
+static enclave_ret_t copy_word_to_host(uintptr_t* dest_ptr, uintptr_t value)
 {
   int region_overlap = 0;
   spinlock_lock(&encl_lock);
@@ -500,6 +570,8 @@ enclave_ret_t copy_word_to_host(uintptr_t* dest_ptr, uintptr_t value)
     return ENCLAVE_SUCCESS;
 }
 
+// TODO: This function is externally used by sm-sbi.c.
+// Change it to be internal (remove from the enclave.h and make static)
 /* Internal function enforcing a copy source is from the untrusted world.
  * Does NOT do verification of dest, assumes caller knows what that is.
  * Dest should be inside the SM memory.
@@ -521,7 +593,7 @@ enclave_ret_t copy_from_host(void* source, void* dest, size_t size){
 }
 
 /* copies data from enclave, source must be inside EPM */
-enclave_ret_t copy_from_enclave(struct enclave_t* enclave,
+static enclave_ret_t copy_from_enclave(struct enclave_t* enclave,
                                 void* dest, void* source, size_t size) {
   int legal = 0;
   spinlock_lock(&encl_lock);
@@ -539,7 +611,7 @@ enclave_ret_t copy_from_enclave(struct enclave_t* enclave,
 }
 
 /* copies data into enclave, destination must be inside EPM */
-enclave_ret_t copy_to_enclave(struct enclave_t* enclave,
+static enclave_ret_t copy_to_enclave(struct enclave_t* enclave,
                               void* dest, void* source, size_t size) {
   int legal = 0;
   spinlock_lock(&encl_lock);
@@ -555,3 +627,4 @@ enclave_ret_t copy_to_enclave(struct enclave_t* enclave,
   else
     return ENCLAVE_SUCCESS;
 }
+

--- a/sm/enclave.h
+++ b/sm/enclave.h
@@ -87,27 +87,6 @@ struct report_t
   byte dev_public_key[PUBLIC_KEY_SIZE];
 };
 
-/*** Internal utils ***/
-void enclave_init_metadata();
-enclave_ret_t _context_switch_to_enclave(uintptr_t* regs,
-                                         eid_t eid,
-                                         int load_parameters);
-void _context_switch_to_host(uintptr_t* encl_regs,
-                             eid_t eid);
-enclave_ret_t init_enclave_memory(uintptr_t base, uintptr_t size,
-                        uintptr_t utbase, uintptr_t utsize);
-enclave_ret_t encl_satp_to_eid(uintptr_t satp, eid_t* eid);
-enclave_ret_t host_satp_to_eid(uintptr_t satp, eid_t* eid);
-enclave_ret_t encl_alloc_eid(eid_t* eid);
-enclave_ret_t encl_free_eid(eid_t eid);
-enclave_ret_t get_host_satp(eid_t eid, unsigned long* satp);
-enclave_ret_t copy_word_to_host(uintptr_t* dest_ptr, uintptr_t value);
-enclave_ret_t copy_from_host(void* source, void* dest, size_t size);
-enclave_ret_t copy_from_enclave(struct enclave_t* enclave,
-                      void* dest, void* source, size_t size);
-enclave_ret_t copy_to_enclave(struct enclave_t* enclave,
-                    void* dest, void* source, size_t size);
-
 /*** SBI functions & external functions ***/
 enclave_ret_t create_enclave(struct keystone_sbi_create_t create_args);
 enclave_ret_t destroy_enclave(eid_t eid);
@@ -116,7 +95,11 @@ enclave_ret_t exit_enclave(uintptr_t* regs, unsigned long retval);
 enclave_ret_t stop_enclave(uintptr_t* regs, uint64_t request);
 enclave_ret_t resume_enclave(uintptr_t* regs, eid_t eid);
 enclave_ret_t attest_enclave(uintptr_t report, uintptr_t data, uintptr_t size);
-
 /* attestation */
 enclave_ret_t hash_enclave(struct enclave_t* enclave);
+// TODO: These functions are supposed to be internal functions.
+void enclave_init_metadata();
+enclave_ret_t copy_from_host(void* source, void* dest, size_t size);
+enclave_ret_t get_host_satp(eid_t eid, unsigned long* satp);
+
 #endif

--- a/sm/enclave.h
+++ b/sm/enclave.h
@@ -49,7 +49,8 @@ struct enclave_t
   byte sign[SIGNATURE_SIZE];
 
   /* parameters */
-  struct runtime_params_t params;
+  struct runtime_va_params_t params;
+  struct runtime_pa_params_t pa_params;
 
   /* enclave execution context */
   unsigned int n_thread;
@@ -98,7 +99,7 @@ enclave_ret_t copy_from_enclave(struct enclave_t* enclave,
 enclave_ret_t copy_to_enclave(struct enclave_t* enclave,
                     void* dest, void* source, size_t size);
 
-/*** SBI functions ***/
+/*** SBI functions & external functions ***/
 enclave_ret_t create_enclave(struct keystone_sbi_create_t create_args);
 enclave_ret_t destroy_enclave(eid_t eid);
 enclave_ret_t run_enclave(uintptr_t* host_regs, eid_t eid);

--- a/sm/sm.h
+++ b/sm/sm.h
@@ -63,18 +63,33 @@ struct keystone_sbi_pregion_t
   uintptr_t paddr;
   size_t size;
 };
-struct runtime_params_t
+struct runtime_va_params_t
 {
-  uint64_t runtime_entry;
-  uint64_t user_entry;
-  uint64_t untrusted_ptr;
-  uint64_t untrusted_size;
+  uintptr_t runtime_entry;
+  uintptr_t user_entry;
+  uintptr_t untrusted_ptr;
+  uintptr_t untrusted_size;
 };
+
+struct runtime_pa_params_t
+{
+  uintptr_t dram_base;
+  uintptr_t dram_size;
+  uintptr_t runtime_base;
+  uintptr_t user_base;
+  uintptr_t free_base;
+};
+
 struct keystone_sbi_create_t
 {
   struct keystone_sbi_pregion_t epm_region;
   struct keystone_sbi_pregion_t utm_region;
-  struct runtime_params_t params;
+
+  uintptr_t runtime_paddr;
+  uintptr_t user_paddr;
+  uintptr_t free_paddr;
+
+  struct runtime_va_params_t params;
   unsigned int* eid_pptr;
 };
 


### PR DESCRIPTION
Please review the last commit separately.

For SeL4 support, we handle the additional parameters passed by the OS.
The additional parameters are all physical addresses (of runtime and eapp), 
which is needed by SeL4 for calculating the offset.
These are not included in the measurement.
Instead, we check if the values are legit using `is_create_args_valid`.

I removed all the internal functions from the header file (enclave.h), because it should not be called in the other files. 3 of them left in the header, since they're used in sm-sbi.h
The last commit switches the order of SBI functions and the internal functions such that the internal functions could be called by SBI functions.