### PR TITLE
Regulate SBI using cpu state struct, no longer use encl_satp to get eid

### DIFF
--- a/sm/cpu.c
+++ b/sm/cpu.c
@@ -1,0 +1,28 @@
+//******************************************************************************
+// Copyright (c) 2018, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+#include "cpu.h"
+
+static struct cpu_state_t cpus[MAX_HARTS];
+
+int cpu_is_enclave_context()
+{
+  return cpus[read_csr(mhartid)].is_enclave != 0;
+}
+
+int cpu_get_enclave_id()
+{
+  return cpus[read_csr(mhartid)].eid;
+}
+
+void cpu_enter_enclave_context(eid_t eid)
+{
+  cpus[read_csr(mhartid)].is_enclave = 1;
+  cpus[read_csr(mhartid)].eid = eid;
+}
+
+void cpu_exit_enclave_context()
+{
+  cpus[read_csr(mhartid)].is_enclave = 0;
+}

--- a/sm/cpu.h
+++ b/sm/cpu.h
@@ -1,0 +1,24 @@
+//******************************************************************************
+// Copyright (c) 2018, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+#ifndef __CPU_H__
+#define __CPU_H__
+
+#include "sm.h"
+#include "enclave.h"
+
+/* hart state for regulating SBI */
+struct cpu_state_t
+{
+  int is_enclave;
+  eid_t eid;
+};
+
+/* external functions */
+int cpu_is_enclave_context();
+int cpu_get_enclave_id();
+void cpu_enter_enclave_context(eid_t eid);
+void cpu_exit_enclave_context();
+
+#endif

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -111,8 +111,6 @@ inline void context_switch_to_host(uintptr_t* encl_regs,
   swap_prev_mepc(&enclaves[eid].threads[0], read_csr(mepc));
   swap_prev_satp(&enclaves[eid].threads[0], read_csr(satp));
 
-  // switch to host page table
-  // write_csr(satp, encl.host_satp);
 
   // enable timer interrupt
   set_csr(mie, MIP_MTIP);

--- a/sm/enclave.h
+++ b/sm/enclave.h
@@ -35,8 +35,6 @@ typedef enum {
 #define STOP_EDGE_CALL_HOST   1
 #define STOP_EXIT_ENCLAVE     2
 
-
-
 /* For now, eid's are a simple unsigned int */
 typedef unsigned int eid_t;
 
@@ -88,13 +86,16 @@ struct report_t
 };
 
 /*** SBI functions & external functions ***/
+// callables from the host
 enclave_ret_t create_enclave(struct keystone_sbi_create_t create_args);
 enclave_ret_t destroy_enclave(eid_t eid);
 enclave_ret_t run_enclave(uintptr_t* host_regs, eid_t eid);
-enclave_ret_t exit_enclave(uintptr_t* regs, unsigned long retval);
-enclave_ret_t stop_enclave(uintptr_t* regs, uint64_t request);
 enclave_ret_t resume_enclave(uintptr_t* regs, eid_t eid);
-enclave_ret_t attest_enclave(uintptr_t report, uintptr_t data, uintptr_t size);
+// callables from the enclave
+enclave_ret_t exit_enclave(uintptr_t* regs, unsigned long retval, eid_t eid);
+enclave_ret_t stop_enclave(uintptr_t* regs, uint64_t request, eid_t eid);
+enclave_ret_t attest_enclave(uintptr_t report, uintptr_t data, uintptr_t size, eid_t eid);
+
 /* attestation */
 enclave_ret_t hash_enclave(struct enclave_t* enclave);
 // TODO: These functions are supposed to be internal functions.

--- a/sm/sm.h
+++ b/sm/sm.h
@@ -39,6 +39,7 @@
 #define ENCLAVE_EDGE_CALL_HOST              (enclave_ret_t)11
 #define ENCLAVE_NOT_INITIALIZED             (enclave_ret_t)12
 #define ENCLAVE_NO_FREE_RESOURCE            (enclave_ret_t)13
+#define ENCLAVE_SBI_PROHIBITED              (enclave_ret_t)14
 
 #define PMP_UNKNOWN_ERROR                   -1U
 #define PMP_SUCCESS                         0

--- a/sm/sm.mk.in
+++ b/sm/sm.mk.in
@@ -5,6 +5,7 @@ sm_hdrs = \
 sm_c_srcs = \
   sm.c \
   sm-sbi.c \
+	cpu.c \
 	thread.c \
   pmp.c \
   enclave.c \

--- a/sm/thread.c
+++ b/sm/thread.c
@@ -33,3 +33,10 @@ void swap_prev_stvec(struct thread_state_t* thread, uintptr_t current_stvec)
   thread->prev_stvec = current_stvec;
   write_csr(stvec, tmp);
 }
+
+void swap_prev_satp(struct thread_state_t* thread, uintptr_t current_satp)
+{
+  uintptr_t tmp = thread->prev_satp;
+  thread->prev_satp = current_satp;
+  write_csr(satp, tmp);
+}

--- a/sm/thread.h
+++ b/sm/thread.h
@@ -47,6 +47,7 @@ struct thread_state_t
 {
   uintptr_t prev_mepc;
   uintptr_t prev_stvec;
+  uintptr_t prev_satp;
   struct ctx_t prev_state;
 };
 
@@ -54,4 +55,5 @@ struct thread_state_t
 void swap_prev_state(struct thread_state_t* state, uintptr_t* regs);
 void swap_prev_mepc(struct thread_state_t* state, uintptr_t mepc);
 void swap_prev_stvec(struct thread_state_t* state, uintptr_t stvec);
+void swap_prev_satp(struct thread_state_t* state, uintptr_t satp);
 #endif /* thread */


### PR DESCRIPTION
We are regulating SM SBI functions such that each function is only
callable by either the host or the enclave.
only callable by the host:
`create_enclave`, `run_enclave`, `destroy_enclave`, `resume_enclave`
only callable by the enclave:
`stop_enclave`, `exit_enclave`, `attest_enclave`

In addition, we no longer use `encl_satp` to get eid, since the satp can
be changed after starting the enclave (both SeL4 and Eyrie could remap
the VA in order to manage its own page table).
Instead, `stop_enclave`, `exit_enclave`, and `attest_enclave` will get eid
from the cpu state.