### PR TITLE
scratchpad support, multiregion enclaves, etc

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -42,6 +42,9 @@
 /* Define if the DTS is to be displayed */
 #undef PK_PRINT_DEVICE_TREE
 
+/* Enable multimem plugin */
+#undef PLUGIN_ENABLE_MULTIMEM
+
 /* Define if subproject MCPPBS_SPROJ_NORM is enabled */
 #undef SM_ENABLED
 

--- a/configure
+++ b/configure
@@ -678,6 +678,7 @@ enable_logo
 with_payload
 with_logo
 with_target_platform
+enable_sm_multimem
 enable_sm
 enable_fp_emulation
 '
@@ -1328,6 +1329,7 @@ Optional Features:
                           Enable all optional subprojects
   --disable-vm            Disable virtual memory
   --enable-logo           Enable boot logo
+  --enable-sm-multimem    Specify sm plugins to include
   --enable-sm             Subproject sm
   --disable-fp-emulation  Disable floating-point emulation
 
@@ -4333,6 +4335,14 @@ if test "${with_target_platform+set}" = set; then :
 
 else
   TARGET_PLATFORM=default
+
+fi
+
+
+# Check whether --enable-sm_multimem was given.
+if test "${enable_sm_multimem+set}" = set; then :
+  enableval=$enable_sm_multimem;
+$as_echo "#define PLUGIN_ENABLE_MULTIMEM /**/" >>confdefs.h
 
 fi
 

--- a/machine/mtrap.c
+++ b/machine/mtrap.c
@@ -189,6 +189,9 @@ send_ipi:
     case SBI_SM_RANDOM:
       retval = mcall_sm_random();
       break;
+    case SBI_SM_CALL_PLUGIN:
+      retval = mcall_sm_call_plugin(arg0, arg1, arg2, arg3);
+      break;
     case SBI_SM_NOT_IMPLEMENTED:
       retval = mcall_sm_not_implemented(regs, arg0);
       break;

--- a/sm/attest.c
+++ b/sm/attest.c
@@ -20,10 +20,10 @@ int validate_and_hash_epm(hash_ctx* hash_ctx, int level,
   //TODO check for failures
   uintptr_t epm_start, epm_size;
   uintptr_t utm_start, utm_size;
-  int idx = get_enclave_region_index(encl, REGION_EPM);
+  int idx = get_enclave_region_index(encl->eid, REGION_EPM);
   epm_start = pmp_region_get_addr(encl->regions[idx].pmp_rid);
   epm_size = pmp_region_get_size(encl->regions[idx].pmp_rid);
-  idx = get_enclave_region_index(encl, REGION_UTM);
+  idx = get_enclave_region_index(encl->eid, REGION_UTM);
   utm_start = pmp_region_get_addr(encl->regions[idx].pmp_rid);
   utm_size = pmp_region_get_size(encl->regions[idx].pmp_rid);
 

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -85,7 +85,7 @@ static inline enclave_ret_code context_switch_to_enclave(uintptr_t* regs,
   pmp_set(enclaves[eid].regions[utm_idx].pmp_rid, PMP_ALL_PERM);
 
   // Setup any platform specific defenses
-  platform_switch_to_enclave(&(enclaves[eid].ped));
+  platform_switch_to_enclave(&(enclaves[eid]));
 
   cpu_enter_enclave_context(eid);
   return ENCLAVE_SUCCESS;
@@ -108,7 +108,7 @@ static inline void context_switch_to_host(uintptr_t* encl_regs,
   set_csr(mie, MIP_MTIP);
 
   // Reconfigure platform specific defenses
-  platform_switch_from_enclave(&(enclaves[eid].ped));
+  platform_switch_from_enclave(&(enclaves[eid]));
 
   cpu_exit_enclave_context();
   return;
@@ -134,7 +134,7 @@ void enclave_init_metadata(){
       enclaves[eid].regions[i].type = REGION_INVALID;
     }
     /* Fire all platform specific init for each enclave */
-    platform_init(&(enclaves[eid].ped));
+    platform_init_enclave(&(enclaves[eid]));
   }
 
 }
@@ -425,8 +425,6 @@ enclave_ret_code create_enclave(struct keystone_sbi_create create_args)
 
   spinlock_unlock(&encl_lock);
 
-  platform_create_enclave(&enclaves[eid].ped);
-
   if(ret != ENCLAVE_SUCCESS)
     goto free_shared_region;
 
@@ -502,7 +500,7 @@ enclave_ret_code destroy_enclave(enclave_id eid)
   }
 
 
-  platform_destroy_enclave(&enclaves[eid].ped);
+  platform_destroy_enclave(&enclaves[eid]);
 
   // 3. release eid
   encl_free_eid(eid);

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -78,9 +78,11 @@ static inline enclave_ret_code context_switch_to_enclave(uintptr_t* regs,
   clear_csr(mip, MIP_SEIP);
 
   // set PMP
-  pmp_set(enclaves[eid].rid, PMP_ALL_PERM);
+  int epm_idx = get_enclave_region_index(&enclaves[eid], REGION_EPM);
+  pmp_set(enclaves[eid].regions[epm_idx].pmp_rid, PMP_ALL_PERM);
   osm_pmp_set(PMP_NO_PERM);
-  pmp_set(enclaves[eid].utrid, PMP_ALL_PERM);
+  int utm_idx = get_enclave_region_index(&enclaves[eid], REGION_UTM);
+  pmp_set(enclaves[eid].regions[utm_idx].pmp_rid, PMP_ALL_PERM);
 
   // Setup any platform specific defenses
   platform_switch_to_enclave(&(enclaves[eid].ped));
@@ -91,11 +93,10 @@ static inline enclave_ret_code context_switch_to_enclave(uintptr_t* regs,
 
 static inline void context_switch_to_host(uintptr_t* encl_regs,
     enclave_id eid){
-  // get the running enclave on this SM
-  struct enclave encl = enclaves[eid];
 
   // set PMP
-  pmp_set(encl.rid, PMP_NO_PERM);
+  int epm_idx = get_enclave_region_index(&enclaves[eid], REGION_EPM);
+  pmp_set(enclaves[eid].regions[epm_idx].pmp_rid, PMP_NO_PERM);
   osm_pmp_set(PMP_ALL_PERM);
 
   /* restore host context */
@@ -122,13 +123,18 @@ static inline void context_switch_to_host(uintptr_t* encl_regs,
  */
 void enclave_init_metadata(){
   enclave_id eid;
+  int i=0;
 
   /* Assumes eids are incrementing values, which they are for now */
   for(eid=0; eid < ENCL_MAX; eid++){
     enclaves[eid].state = INVALID;
 
+    // Clear out regions
+    for(i=0; i < ENCLAVE_REGIONS_MAX; i++){
+      enclaves[eid].regions[i].type = REGION_INVALID;
+    }
     /* Fire all platform specific init for each enclave */
-    platform_init_enclave(&(enclaves[eid].ped));
+    platform_init(&(enclaves[eid].ped));
   }
 
 }
@@ -179,6 +185,16 @@ static enclave_ret_code encl_free_eid(enclave_id eid)
   return ENCLAVE_SUCCESS;
 }
 
+int get_enclave_region_index(struct enclave* enclave, enum enclave_region_type type){
+  size_t i;
+  for(i = 0;i < ENCLAVE_REGIONS_MAX; i++){
+    if(enclave->regions[i].type == type){
+      return i;
+    }
+  }
+  // No such region for this enclave
+  return -1;
+}
 /* Ensures that dest ptr is in host, not in enclave regions
  */
 static enclave_ret_code copy_word_to_host(uintptr_t* dest_ptr, uintptr_t value)
@@ -219,14 +235,33 @@ enclave_ret_code copy_from_host(void* source, void* dest, size_t size){
     return ENCLAVE_SUCCESS;
 }
 
+static int buffer_in_enclave_region(struct enclave* enclave,
+                                    void* start, size_t size){
+  int legal = 0;
+
+  int i;
+  /* Check if the source is in a valid region */
+  for(i = 0; i < ENCLAVE_REGIONS_MAX; i++){
+    if(enclave->regions[i].type == REGION_INVALID ||
+       enclave->regions[i].type == REGION_UTM)
+      continue;
+    uintptr_t region_start = pmp_region_get_addr(enclave->regions[i].pmp_rid);
+    size_t region_size = pmp_region_get_size(enclave->regions[i].pmp_rid);
+    if(start >= (void*)region_start
+       && start + size <= (void*)(region_start + region_size)){
+      return 1;
+    }
+  }
+  return 0;
+}
+
 /* copies data from enclave, source must be inside EPM */
 static enclave_ret_code copy_from_enclave(struct enclave* enclave,
-                                void* dest, void* source, size_t size) {
-  int legal = 0;
+                                          void* dest, void* source, size_t size) {
+
   spinlock_lock(&encl_lock);
-  legal = (source >= (void*) pmp_region_get_addr(enclave->rid)
-      && source + size <= (void*) pmp_region_get_addr(enclave->rid) +
-      pmp_region_get_size(enclave->rid));
+  int legal = buffer_in_enclave_region(enclave, source, size);
+
   if(legal)
     memcpy(dest, source, size);
   spinlock_unlock(&encl_lock);
@@ -239,12 +274,10 @@ static enclave_ret_code copy_from_enclave(struct enclave* enclave,
 
 /* copies data into enclave, destination must be inside EPM */
 static enclave_ret_code copy_to_enclave(struct enclave* enclave,
-                              void* dest, void* source, size_t size) {
-  int legal = 0;
+                                        void* dest, void* source, size_t size) {
   spinlock_lock(&encl_lock);
-  legal = (dest >= (void*) pmp_region_get_addr(enclave->rid)
-      && dest + size <= (void*) pmp_region_get_addr(enclave->rid) +
-      pmp_region_get_size(enclave->rid));
+  int legal = buffer_in_enclave_region(enclave, dest, size);
+
   if(legal)
     memcpy(dest, source, size);
   spinlock_unlock(&encl_lock);
@@ -363,10 +396,15 @@ enclave_ret_code create_enclave(struct keystone_sbi_create create_args)
   // cleanup some memory regions for sanity See issue #38
   clean_enclave_memory(utbase, utsize);
 
+
   // initialize enclave metadata
   enclaves[eid].eid = eid;
-  enclaves[eid].rid = region;
-  enclaves[eid].utrid = shared_region;
+
+  enclaves[eid].regions[0].pmp_rid = region;
+  enclaves[eid].regions[0].type = REGION_EPM;
+  enclaves[eid].regions[1].pmp_rid = shared_region;
+  enclaves[eid].regions[1].type = REGION_UTM;
+
   //print_pgtable(3, (pte_t*) (read_csr(satp) << RISCV_PGSHIFT), 0);
   enclaves[eid].encl_satp = ((base >> RISCV_PGSHIFT) | SATP_MODE_CHOICE);
   enclaves[eid].n_thread = 0;
@@ -376,11 +414,14 @@ enclave_ret_code create_enclave(struct keystone_sbi_create create_args)
   /* Init enclave state (regs etc) */
   clean_state(&enclaves[eid].threads[0]);
 
+  /* Platform create happens as the last thing before hashing/etc since
+     it may modify the enclave struct */
+  platform_create_enclave(&enclaves[eid]);
+
   /* Validate memory, prepare hash and signature for attestation */
   spinlock_lock(&encl_lock);
   enclaves[eid].state = FRESH;
-  ret = validate_and_hash_enclave(&enclaves[eid],
-                                  &create_args);
+  ret = validate_and_hash_enclave(&enclaves[eid]);
 
   spinlock_unlock(&encl_lock);
 
@@ -426,25 +467,40 @@ enclave_ret_code destroy_enclave(enclave_id eid)
   if(!destroyable)
     return ENCLAVE_NOT_DESTROYABLE;
 
-  // 1. clear all the data in the enclave page
+  // 1. clear all the data in the enclave pages
   // requires no lock (single runner)
-  void* base = (void*) pmp_region_get_addr(enclaves[eid].rid);
-  size_t size = (size_t) pmp_region_get_size(enclaves[eid].rid);
+  int i;
+  void* base;
+  size_t size;
+  region_id rid;
+  for(i = 0; i < ENCLAVE_REGIONS_MAX; i++){
+    if(enclaves[eid].regions[i].type == REGION_INVALID ||
+       enclaves[eid].regions[i].type == REGION_UTM)
+      continue;
+    //1.a Clear all pages
+    rid = enclaves[eid].regions[i].pmp_rid;
+    base = (void*) pmp_region_get_addr(rid);
+    size = (size_t) pmp_region_get_size(rid);
+    memset((void*) base, 0, size);
 
-  memset((void*) base, 0, size);
+    //1.b free pmp region
+    pmp_unset_global(rid);
+    pmp_region_free_atomic(rid);
+  }
 
-  // 2. free pmp region
-  pmp_unset_global(enclaves[eid].rid);
-  pmp_region_free_atomic(enclaves[eid].rid);
-  pmp_region_free_atomic(enclaves[eid].utrid);
+  // 2. free pmp region for UTM
+  rid = get_enclave_region_index(&enclaves[eid], REGION_UTM);
+  if(rid != -1)
+    pmp_region_free_atomic(enclaves[eid].regions[rid].pmp_rid);
 
-  enclaves[eid].eid = 0;
-  enclaves[eid].rid = 0;
-  enclaves[eid].utrid = 0;
   enclaves[eid].encl_satp = 0;
   enclaves[eid].n_thread = 0;
   enclaves[eid].params = (struct runtime_va_params_t) {0};
   enclaves[eid].pa_params = (struct runtime_pa_params) {0};
+  for(i=0; i < ENCLAVE_REGIONS_MAX; i++){
+    enclaves[eid].regions[i].type = REGION_INVALID;
+  }
+
 
   platform_destroy_enclave(&enclaves[eid].ped);
 

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -123,9 +123,6 @@ static inline void context_switch_to_host(uintptr_t* encl_regs,
 void enclave_init_metadata(){
   enclave_id eid;
 
-  /* Fire platform specific global init */
-  platform_init_global();
-
   /* Assumes eids are incrementing values, which they are for now */
   for(eid=0; eid < ENCL_MAX; eid++){
     enclaves[eid].state = INVALID;

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -465,6 +465,11 @@ enclave_ret_code destroy_enclave(enclave_id eid)
   if(!destroyable)
     return ENCLAVE_NOT_DESTROYABLE;
 
+
+  // 0. Let the platform specifics do cleanup/modifications
+  platform_destroy_enclave(&enclaves[eid]);
+
+
   // 1. clear all the data in the enclave pages
   // requires no lock (single runner)
   int i;
@@ -498,9 +503,6 @@ enclave_ret_code destroy_enclave(enclave_id eid)
   for(i=0; i < ENCLAVE_REGIONS_MAX; i++){
     enclaves[eid].regions[i].type = REGION_INVALID;
   }
-
-
-  platform_destroy_enclave(&enclaves[eid]);
 
   // 3. release eid
   encl_free_eid(eid);

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -86,7 +86,6 @@ static inline enclave_ret_code context_switch_to_enclave(uintptr_t* regs,
 
   // Setup any platform specific defenses
   platform_switch_to_enclave(&(enclaves[eid]));
-
   cpu_enter_enclave_context(eid);
   return ENCLAVE_SUCCESS;
 }
@@ -309,6 +308,15 @@ static int is_create_args_valid(struct keystone_sbi_create* args)
 {
   uintptr_t epm_start, epm_end;
 
+  /* printm("[create args info]: \r\n\tepm_addr: %llx\r\n\tepmsize: %llx\r\n\tutm_addr: %llx\r\n\tutmsize: %llx\r\n\truntime_addr: %llx\r\n\tuser_addr: %llx\r\n\tfree_addr: %llx\r\n", */
+  /*        args->epm_region.paddr, */
+  /*        args->epm_region.size, */
+  /*        args->utm_region.paddr, */
+  /*        args->utm_region.size, */
+  /*        args->runtime_paddr, */
+  /*        args->user_paddr, */
+  /*        args->free_paddr); */
+
   // check if physical addresses are valid
   if (args->epm_region.size <= 0)
     return 0;
@@ -341,10 +349,6 @@ static int is_create_args_valid(struct keystone_sbi_create* args)
     return 0;
   if (args->user_paddr > args->free_paddr)
     return 0;
-
-  /* printm("[create args] runtimep: %lx userp: %lx epm_end: %lx epm_start: %lx\r\n", */
-  /*        args->runtime_paddr, args->user_paddr, */
-  /*        epm_end, epm_start); */
 
   return 1;
 }
@@ -422,7 +426,6 @@ enclave_ret_code create_enclave(struct keystone_sbi_create create_args)
   enclaves[eid].regions[1].pmp_rid = shared_region;
   enclaves[eid].regions[1].type = REGION_UTM;
 
-  //print_pgtable(3, (pte_t*) (read_csr(satp) << RISCV_PGSHIFT), 0);
   enclaves[eid].encl_satp = ((base >> RISCV_PGSHIFT) | SATP_MODE_CHOICE);
   enclaves[eid].n_thread = 0;
   enclaves[eid].params = params;
@@ -439,7 +442,6 @@ enclave_ret_code create_enclave(struct keystone_sbi_create create_args)
   spinlock_lock(&encl_lock);
   enclaves[eid].state = FRESH;
   ret = validate_and_hash_enclave(&enclaves[eid]);
-
   spinlock_unlock(&encl_lock);
 
   if(ret != ENCLAVE_SUCCESS)
@@ -526,6 +528,7 @@ enclave_ret_code destroy_enclave(enclave_id eid)
 
   return ENCLAVE_SUCCESS;
 }
+
 
 enclave_ret_code run_enclave(uintptr_t* host_regs, enclave_id eid)
 {

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -198,12 +198,18 @@ int get_enclave_region_index(enclave_id eid, enum enclave_region_type type){
 
 uintptr_t get_enclave_region_size(enclave_id eid, int memid)
 {
-  return pmp_region_get_size(enclaves[eid].regions[memid].pmp_rid);
+  if (0 <= memid && memid < ENCLAVE_REGIONS_MAX)
+    return pmp_region_get_size(enclaves[eid].regions[memid].pmp_rid);
+
+  return 0;
 }
 
 uintptr_t get_enclave_region_base(enclave_id eid, int memid)
 {
-  return pmp_region_get_size(enclaves[eid].regions[memid].pmp_rid);
+  if (0 <= memid && memid < ENCLAVE_REGIONS_MAX)
+    return pmp_region_get_size(enclaves[eid].regions[memid].pmp_rid);
+
+  return 0;
 }
 
 /* Ensures that dest ptr is in host, not in enclave regions

--- a/sm/enclave.h
+++ b/sm/enclave.h
@@ -122,6 +122,7 @@ enclave_ret_code validate_and_hash_enclave(struct enclave* enclave);
 // TODO: These functions are supposed to be internal functions.
 void enclave_init_metadata();
 enclave_ret_code copy_from_host(void* source, void* dest, size_t size);
-int get_enclave_region_index(struct enclave* enclave, enum enclave_region_type type);
-
+int get_enclave_region_index(enclave_id eid, enum enclave_region_type type);
+uintptr_t get_enclave_region_base(enclave_id eid, int memid);
+uintptr_t get_enclave_region_size(enclave_id eid, int memid);
 #endif

--- a/sm/enclave.h
+++ b/sm/enclave.h
@@ -123,5 +123,4 @@ enclave_ret_code validate_and_hash_enclave(struct enclave* enclave);
 void enclave_init_metadata();
 enclave_ret_code copy_from_host(void* source, void* dest, size_t size);
 int get_enclave_region_index(struct enclave* enclave, enum enclave_region_type type);
-
 #endif

--- a/sm/platform.h
+++ b/sm/platform.h
@@ -9,6 +9,8 @@
 void platform_init_enclave(struct platform_enclave_data* enclave);
 
 /* This fires once GLOBALLY before any other platform init */
+void platform_init_global_once();
+/* Fires once per-hart after global_once */
 void platform_init_global();
 
 /* This fires once each time an enclave is created by the sm */

--- a/sm/platform.h
+++ b/sm/platform.h
@@ -9,12 +9,12 @@
 void platform_init_enclave(struct enclave* enclave);
 
 /* This fires once GLOBALLY before any other platform init */
-void platform_init_global_once();
+enclave_ret_code platform_init_global_once();
 /* Fires once per-hart after global_once */
-void platform_init_global();
+enclave_ret_code platform_init_global();
 
 /* This fires once each time an enclave is created by the sm */
-void platform_create_enclave(struct enclave* enclave);
+enclave_ret_code platform_create_enclave(struct enclave* enclave);
 
 /* This fires once each time an enclave is destroyed by the sm */
 void platform_destroy_enclave(struct enclave* enclave);
@@ -34,4 +34,5 @@ void platform_switch_from_enclave(struct enclave* enclave);
    demand and never fail. If it would fail it may power off
    instead. */
 uint64_t platform_random();
+
 #endif /* _PLATFORM_H_ */

--- a/sm/platform.h
+++ b/sm/platform.h
@@ -6,7 +6,7 @@
 
 /* This fires once FOR EACH sm supported enclave during init of
    enclave metadata. It may not fail currently. */
-void platform_init_enclave(struct platform_enclave_data* enclave);
+void platform_init_enclave(struct enclave* enclave);
 
 /* This fires once GLOBALLY before any other platform init */
 void platform_init_global_once();
@@ -14,16 +14,16 @@ void platform_init_global_once();
 void platform_init_global();
 
 /* This fires once each time an enclave is created by the sm */
-void platform_create_enclave(struct platform_enclave_data* enclave);
+void platform_create_enclave(struct enclave* enclave);
 
 /* This fires once each time an enclave is destroyed by the sm */
-void platform_destroy_enclave(struct platform_enclave_data* enclave);
+void platform_destroy_enclave(struct enclave* enclave);
 
 /* This fires when context switching INTO an enclave from the OS */
-void platform_switch_to_enclave(struct platform_enclave_data* enclave);
+void platform_switch_to_enclave(struct enclave* enclave);
 
 /* This fires when context switching OUT of an enclave into the OS */
-void platform_switch_from_enclave(struct platform_enclave_data* enclave);
+void platform_switch_from_enclave(struct enclave* enclave);
 
 /* Future version: This fires when context switching from enclave A to
    enclave B */

--- a/sm/platform.h
+++ b/sm/platform.h
@@ -4,9 +4,18 @@
 /* These functions are defined by platform/soc specific objects,
    defined in platform/$PLATFORM/$PLATFORM.c */
 
-/* This fires once FOR EACH enclave during init of enclave
-   metadata. It may not fail currently. */
-void platform_init(struct platform_enclave_data* enclave);
+/* This fires once FOR EACH sm supported enclave during init of
+   enclave metadata. It may not fail currently. */
+void platform_init_enclave(struct platform_enclave_data* enclave);
+
+/* This fires once GLOBALLY before any other platform init */
+void platform_init_global();
+
+/* This fires once each time an enclave is created by the sm */
+void platform_create_enclave(struct platform_enclave_data* enclave);
+
+/* This fires once each time an enclave is destroyed by the sm */
+void platform_destroy_enclave(struct platform_enclave_data* enclave);
 
 /* This fires when context switching INTO an enclave from the OS */
 void platform_switch_to_enclave(struct platform_enclave_data* enclave);

--- a/sm/platform/default/default.c
+++ b/sm/platform/default/default.c
@@ -9,23 +9,23 @@ void platform_init_global(){
   return;
 }
 
-void platform_init_enclave(struct platform_enclave_data* enclave){
+void platform_init_enclave(struct enclave* enclave){
   return;
 }
 
-void platform_destroy_enclave(struct platform_enclave_data* enclave){
+void platform_destroy_enclave(struct enclave* enclave){
   return;
 }
 
-void platform_create_enclave(struct platform_enclave_data* enclave){
+void platform_create_enclave(struct enclave* enclave){
   return;
 }
 
-void platform_switch_to_enclave(struct platform_enclave_data* enclave){
+void platform_switch_to_enclave(struct enclave* enclave){
   return;
 }
 
-void platform_switch_from_enclave(struct platform_enclave_data* enclave){
+void platform_switch_from_enclave(struct enclave* enclave){
   return;
 }
 

--- a/sm/platform/default/default.c
+++ b/sm/platform/default/default.c
@@ -1,7 +1,11 @@
 /* Default platform does nothing special here */
 #include "enclave.h"
 
-void platform_init(struct platform_enclave_data* enclave){
+void platform_init_global(){
+  return;
+}
+
+void platform_init_enclave(struct platform_enclave_data* enclave){
   return;
 }
 

--- a/sm/platform/default/default.c
+++ b/sm/platform/default/default.c
@@ -13,6 +13,14 @@ void platform_init_enclave(struct platform_enclave_data* enclave){
   return;
 }
 
+void platform_destroy_enclave(struct platform_enclave_data* enclave){
+  return;
+}
+
+void platform_create_enclave(struct platform_enclave_data* enclave){
+  return;
+}
+
 void platform_switch_to_enclave(struct platform_enclave_data* enclave){
   return;
 }

--- a/sm/platform/default/default.c
+++ b/sm/platform/default/default.c
@@ -1,12 +1,12 @@
 /* Default platform does nothing special here */
 #include "enclave.h"
 
-void platform_init_global_once(){
-  return;
+enclave_ret_code platform_init_global_once(){
+  return ENCLAVE_SUCCESS;
 }
 
-void platform_init_global(){
-  return;
+enclave_ret_code platform_init_global(){
+  return ENCLAVE_SUCCESS;
 }
 
 void platform_init_enclave(struct enclave* enclave){
@@ -17,8 +17,8 @@ void platform_destroy_enclave(struct enclave* enclave){
   return;
 }
 
-void platform_create_enclave(struct enclave* enclave){
-  return;
+enclave_ret_code platform_create_enclave(struct enclave* enclave){
+  return ENCLAVE_SUCCESS;
 }
 
 void platform_switch_to_enclave(struct enclave* enclave){

--- a/sm/platform/default/default.c
+++ b/sm/platform/default/default.c
@@ -1,6 +1,10 @@
 /* Default platform does nothing special here */
 #include "enclave.h"
 
+void platform_init_global_once(){
+  return;
+}
+
 void platform_init_global(){
   return;
 }

--- a/sm/platform/fu540/fu540.c
+++ b/sm/platform/fu540/fu540.c
@@ -1,14 +1,9 @@
 #include "fu540_internal.c"
 #include "waymasks.c"
 
-void platform_getrandom_fill(uint8_t* buffer, unsigned long size){
-
+uint64_t platform_random(){
 #pragma message("Platform has no entropy source, this is unsafe. TEST ONLY")
   unsigned long cycles;
-  while(size > 0){
-    asm volatile ("rdcycle %0" : "=r" (cycles));
-    *buffer = cycles % 255;
-    size--;
-    buffer++;
-  }
+  asm volatile ("rdcycle %0" : "=r" (cycles));
+  return cycles;
 }

--- a/sm/platform/fu540/fu540.h
+++ b/sm/platform/fu540/fu540.h
@@ -3,11 +3,12 @@
 
 #include "waymasks.h"
 
-struct platform_enclave_data_t {
+struct platform_enclave_data {
 
   size_t num_ways;
   waymask_t saved_mask;
-
+  waymask_t scratchpad_mask;
+  int scratch_rid;
 };
 
 #endif /* _FU540_H_ */

--- a/sm/platform/fu540/fu540.h
+++ b/sm/platform/fu540/fu540.h
@@ -4,11 +4,14 @@
 #include "waymasks.h"
 
 struct platform_enclave_data {
-
+  /* 0 means don't do cache partitioning. Otherwise the number of ways
+     required. */
   size_t num_ways;
+  /* Used if there is a waymask needed (>0 num_ways)*/
   waymask_t saved_mask;
-  waymask_t scratchpad_mask;
-  int scratch_rid;
+
+  /* 0 for doesn't use scratchpad, 1 for does */
+  int use_scratch;
 };
 
 #endif /* _FU540_H_ */

--- a/sm/platform/fu540/fu540_internal.c
+++ b/sm/platform/fu540/fu540_internal.c
@@ -7,90 +7,155 @@
 #include "page.h"
 #include <string.h>
 
+void scratch_init(){
+  if(scratchpad_allocated_ways != 0){
+    return;
+  }
+
+  /* TODO TMP way to try and get the scratchpad allocated */
+  waymask_allocate_scratchpad(&scratchpad_allocated_ways);
+
+  region_id masks_rid;
+  if(pmp_region_init_atomic((uintptr_t)WM_REG_ADDR(0)&(~0xfff), RISCV_PGSIZE, PMP_PRI_ANY, &masks_rid, 1)){
+    printm("FATAL CANNOT CREATE PMP FOR MASKS\r\n");
+  }
+  /* Create PMP region for scratchpad */
+  if(pmp_region_init_atomic(L2_SCRATCH_START, 8*L2_WAY_SIZE, PMP_PRI_ANY, &scratch_rid, 1)){
+    printm("FATAL CANNOT CREATE SCRATCH PMP\r\n");
+    //TODO: this isn't currently fatal!
+  }
+
+  pmp_set_global(masks_rid, PMP_NO_PERM);
+  pmp_set_global(scratch_rid, PMP_NO_PERM);
+
+
+  /* Clear scratchpad for use */
+  unsigned int core = read_csr(mhartid);
+  waymask_apply_allocated_mask(scratchpad_allocated_ways, core);
+
+  waymask_t invert_mask = WM_FLIP_MASK(scratchpad_allocated_ways);
+  _wm_assign_mask(invert_mask, core*2+1);
+
+  /* This section is quite delicate, and may need to be re-written in
+     assembly. Fundamentally, we are going to create a scratchpad
+     region in the L2 based on the given mask (assuming that the mask
+     is contiguous bits.
+  */
+
+  /* Choose a start/stop physical address to use for the
+  scratchpad. As long as we choose contiguous addresses in the L2 Zero
+  Device that total the size of the allocated ways, they don't really
+  matter */
+  uintptr_t scratch_start = L2_SCRATCH_START;
+  uintptr_t scratch_stop = L2_SCRATCH_START + (8 *  L2_WAY_SIZE);
+  waymask_t tmp_mask;
+  uintptr_t addr;
+
+ fill_scratch:
+  addr = scratch_start;
+  /* We will be directly setting the master d$ mask to avoid any cache
+     pollution issues */
+  waymask_t* master_mask = WM_REG_ADDR(core*2);
+  /* Go through the mask one way at a time to control the allocations */
+  for(tmp_mask=0x80;
+      tmp_mask <= scratchpad_allocated_ways;
+      tmp_mask = tmp_mask << 1){
+    uintptr_t way_end  = addr + L2_WAY_SIZE;
+    /* Assign a temporary mask of 1 way to the d$ */
+    *master_mask = tmp_mask;
+    /* Write a known value to every L2_LINE_SIZE offset */
+    for(;
+        addr < way_end;
+        addr+= L2_LINE_SIZE){
+      *(uintptr_t*)addr = 64;
+    }
+    /* Disable as soon as possible */
+    *master_mask = invert_mask;
+  }
+
+  /* At this point, no master has waymasks for the scratchpad ways,
+     and all scratchpad addresses have L2 lines */
+
+  /* We try and check it now, any error SHOULD be immediately detectable. */
+  /* Any detected error will cause a bad L2 fill, which will be flushed above */
+  for(addr = scratch_start; addr < scratch_stop; addr += L2_LINE_SIZE){
+    if(*(uintptr_t*)addr != 64){
+      printm("Found a bad line %x, retrying\r\n", addr);
+      *L2_FLUSH64_REG = addr;
+      goto fill_scratch;
+    }
+  }
+
+}
+
 void platform_init_global(){
 
   waymask_init();
 
-  /* Lock off part of the L2 for use as scratchpad */
+  scratchpad_allocated_ways = 0;
 
+  printm("Global fu540 module init done\r\n");
+
+  unsigned int hartid = read_csr(mhartid);
+  printm("mhartid: %x, coremasters: %x & %x\r\n",hartid, (hartid)*2, (hartid)*2 + 1);
 
 }
 
 void platform_init_enclave(struct platform_enclave_data* ped){
-  ped->num_ways = WM_NUM_WAYS/2;
+  ped->num_ways = 0; // DISABLE waymasking
+  //ped->num_ways = WM_NUM_WAYS/2;
   ped->saved_mask = 0;
-  ped->scratchpad_mask = 0;
 }
 
 void platform_create_enclave(struct platform_enclave_data* ped){
-  /* TODO TMP way to try and get the scratchpad allocated */
-  waymask_allocate_scratchpad(&ped->scratchpad_mask);
+  scratch_init();
 
-  /* Clear scratchpad for use */
-  unsigned int core = read_csr(mhartid) + 1;
-  waymask_apply_allocated_mask(ped->scratchpad_mask, core);
-
-  /* High ways to low ways */
-  /* TMP */
-  uintptr_t addr;
-  for(addr=L2_SCRATCH_START;
-      addr<(L2_SCRATCH_START + (8 * L2_WAY_SIZE));
-      addr+=sizeof(uintptr_t)){
-    *(uintptr_t*)addr = 0;
-  }
-  /* TMP turn off access */
-  _wm_assign_mask(0xFFFF,GET_CORE_DWAY(core));
-
-  ped->scratch_rid = 0;
-  /* TMP create pmp region */
-  if(pmp_region_init_atomic(L2_SCRATCH_START, 8*L2_WAY_SIZE, PMP_PRI_ANY, &ped->scratch_rid, 0)){
-    printm("FATAL CANNOT CREATE SCRATCH PMP\r\n");
-  }
-
+  ped->use_scratch = 1;
   printm("Created enclave, attempted to give it scratch\r\n");
 }
 
 void platform_destroy_enclave(struct platform_enclave_data* ped){
-  if(ped->scratchpad_mask != 0){
-    waymask_free_scratchpad(&ped->scratchpad_mask);
-  }
-  unsigned int core = read_csr(mhartid) + 1;
-  _wm_assign_mask(0xFFFFFFFF,GET_CORE_DWAY(core));
+  unsigned int core = read_csr(mhartid);
+  ped->use_scratch = 0;
+
+  /* TODO Must clean out the scratchpad if it was in use! */
+
 }
 
 void platform_switch_to_enclave(struct platform_enclave_data* ped){
 
-  // Each hart gets special access to some
-  //unsigned int core = read_csr(mhartid) + 1;
+   if(ped->num_ways > 0){
+    // Each hart gets special access to some
+    unsigned int core = read_csr(mhartid);
 
-  /* Allocate ways, fresh every time we enter */
-  /* size_t remaining = waymask_allocate_ways(ped->num_ways, */
-  /*                                          core, */
-  /*                                          &ped->saved_mask); */
+    //Allocate ways, fresh every time we enter
+    size_t remaining = waymask_allocate_ways(ped->num_ways,
+                                             core,
+                                             &ped->saved_mask);
 
-  //printm("Chose ways: 0x%x, core 0x%x\r\n",ped->saved_mask, core);
+    //printm("Chose ways: 0x%x, core 0x%x\r\n",ped->saved_mask, core);
+    /* Assign the ways to all cores */
+    waymask_apply_allocated_mask(ped->saved_mask, core);
 
-
-  /* Assign the ways to all cores */
-  //  waymask_apply_allocated_mask(ped->saved_mask, core);
-
-  /* Clear out these ways MUST first apply mask to other masters */
-  //waymask_clear_ways(ped->saved_mask, core);
-
-
-  /* Setup PMP region for scratchpad */
-  if(ped->scratch_rid != 0){
-    pmp_set(ped->scratch_rid, PMP_ALL_PERM);
-    printm("Switching to an enclave with scratchpad access\r\n");
+    /* Clear out these ways MUST first apply mask to other masters */
+    waymask_clear_ways(ped->saved_mask, core);
   }
 
+  /* Setup PMP region for scratchpad */
+  if(ped->use_scratch != 0){
+    pmp_set(scratch_rid, PMP_ALL_PERM);
+    printm("Switching to an enclave with scratchpad access\r\n");
+  }
+  waymask_debug_printstatus();
 
 }
 
 void platform_switch_from_enclave(struct platform_enclave_data* ped){
-  /* Free all our ways */
-  //  waymask_free_ways(ped->saved_mask);
-
+  if(ped->num_ways > 0){
+    /* Free all our ways */
+    waymask_free_ways(ped->saved_mask);
+  }
+  pmp_set(scratch_rid, PMP_NO_PERM);
   /* We don't need to clean them, see docs */
 
 }

--- a/sm/platform/fu540/fu540_internal.c
+++ b/sm/platform/fu540/fu540_internal.c
@@ -176,12 +176,23 @@ enclave_ret_code platform_create_enclave(struct enclave* enclave){
 
 void platform_destroy_enclave(struct enclave* enclave){
   if(enclave->ped.use_scratch){
+    int scratch_epm_idx = get_enclave_region_index(enclave->eid, REGION_EPM);
     /* Clean out the region ourselves */
-    /* TODO wipe */
+
+    /* Should be safe to just write to the memory addresses we used to
+       initialize */
+    uintptr_t addr;
+    uintptr_t scratch_start = pmp_region_get_addr(enclave->regions[scratch_epm_idx].pmp_rid);
+    uintptr_t scratch_stop = scratch_start + pmp_region_get_size(enclave->regions[scratch_epm_idx].pmp_rid);
+    for( addr = scratch_start;
+         addr < scratch_stop;
+         addr += sizeof(uintptr_t)){
+      *(uintptr_t*)addr = 0;
+    }
 
     /* Fix the enclave region info to no longer know about
        scratchpad */
-    int scratch_epm_idx = get_enclave_region_index(enclave->eid, REGION_EPM);
+
     enclave->regions[scratch_epm_idx].type = REGION_INVALID;
 
     /* Free the scratchpad */

--- a/sm/platform/fu540/fu540_internal.c
+++ b/sm/platform/fu540/fu540_internal.c
@@ -15,18 +15,6 @@ void scratch_init(){
   /* TODO TMP way to try and get the scratchpad allocated */
   waymask_allocate_scratchpad(&scratchpad_allocated_ways);
 
-  region_id masks_rid;
-  if(pmp_region_init_atomic((uintptr_t)WM_REG_ADDR(0)&(~0xfff), RISCV_PGSIZE, PMP_PRI_ANY, &masks_rid, 1)){
-    printm("FATAL CANNOT CREATE PMP FOR MASKS\r\n");
-  }
-  /* Create PMP region for scratchpad */
-  if(pmp_region_init_atomic(L2_SCRATCH_START, 8*L2_WAY_SIZE, PMP_PRI_ANY, &scratch_rid, 1)){
-    printm("FATAL CANNOT CREATE SCRATCH PMP\r\n");
-    //TODO: this isn't currently fatal!
-  }
-
-  pmp_set_global(masks_rid, PMP_NO_PERM);
-  pmp_set_global(scratch_rid, PMP_NO_PERM);
 
 
   /* Clear scratchpad for use */
@@ -43,15 +31,14 @@ void scratch_init(){
   */
 
   /* Choose a start/stop physical address to use for the
-  scratchpad. As long as we choose contiguous addresses in the L2 Zero
-  Device that total the size of the allocated ways, they don't really
-  matter */
+     scratchpad. As long as we choose contiguous addresses in the L2
+     Zero Device that total the size of the allocated ways, they don't
+     really matter */
   uintptr_t scratch_start = L2_SCRATCH_START;
   uintptr_t scratch_stop = L2_SCRATCH_START + (8 *  L2_WAY_SIZE);
   waymask_t tmp_mask;
   uintptr_t addr;
 
- fill_scratch:
   addr = scratch_start;
   /* We will be directly setting the master d$ mask to avoid any cache
      pollution issues */
@@ -77,27 +64,40 @@ void scratch_init(){
      and all scratchpad addresses have L2 lines */
 
   /* We try and check it now, any error SHOULD be immediately detectable. */
-  /* Any detected error will cause a bad L2 fill, which will be flushed above */
   for(addr = scratch_start; addr < scratch_stop; addr += L2_LINE_SIZE){
     if(*(uintptr_t*)addr != 64){
-      printm("Found a bad line %x, retrying\r\n", addr);
-      *L2_FLUSH64_REG = addr;
-      goto fill_scratch;
+      printm("FATAL: Found a bad line %x\r\n", addr);
+      /* TODO Not fatal! */
     }
   }
 
 }
 
-void platform_init_global(){
+void platform_init_global_once(){
 
   waymask_init();
-
   scratchpad_allocated_ways = 0;
 
-  printm("Global fu540 module init done\r\n");
+  /* PMP Lock the entire L2 controller */
+  if(pmp_region_init_atomic(CACHE_CONTROLLER_ADDR_START,
+                            CACHE_CONTROLLER_ADDR_END - CACHE_CONTROLLER_ADDR_START,
+                            PMP_PRI_ANY, &l2_controller_rid, 1)){
+    printm("FATAL CANNOT CREATE PMP FOR CONTROLLER\r\n");
+    //TODO: this isn't currently fatal!
+  }
+  /* Create PMP region for scratchpad */
+  if(pmp_region_init_atomic(L2_SCRATCH_START,
+                            L2_SCRATCH_STOP - L2_SCRATCH_START,
+                            PMP_PRI_ANY, &scratch_rid, 1)){
+    printm("FATAL CANNOT CREATE SCRATCH PMP\r\n");
+    //TODO: this isn't currently fatal!
+  }
+}
 
-  unsigned int hartid = read_csr(mhartid);
-  printm("mhartid: %x, coremasters: %x & %x\r\n",hartid, (hartid)*2, (hartid)*2 + 1);
+
+void platform_init_global(){
+  pmp_set(l2_controller_rid, PMP_NO_PERM);
+  pmp_set(scratch_rid, PMP_NO_PERM);
 
 }
 
@@ -111,7 +111,7 @@ void platform_create_enclave(struct platform_enclave_data* ped){
   scratch_init();
 
   ped->use_scratch = 1;
-  printm("Created enclave, attempted to give it scratch\r\n");
+  //
 }
 
 void platform_destroy_enclave(struct platform_enclave_data* ped){
@@ -144,18 +144,18 @@ void platform_switch_to_enclave(struct platform_enclave_data* ped){
   /* Setup PMP region for scratchpad */
   if(ped->use_scratch != 0){
     pmp_set(scratch_rid, PMP_ALL_PERM);
-    printm("Switching to an enclave with scratchpad access\r\n");
+    //printm("Switching to an enclave with scratchpad access\r\n");
   }
-  waymask_debug_printstatus();
-
 }
 
 void platform_switch_from_enclave(struct platform_enclave_data* ped){
   if(ped->num_ways > 0){
     /* Free all our ways */
     waymask_free_ways(ped->saved_mask);
+    /* We don't need to clean them, see docs */
   }
-  pmp_set(scratch_rid, PMP_NO_PERM);
-  /* We don't need to clean them, see docs */
+  if(ped->use_scratch != 0){
+    pmp_set(scratch_rid, PMP_NO_PERM);
+  }
 
 }

--- a/sm/platform/fu540/fu540_internal.c
+++ b/sm/platform/fu540/fu540_internal.c
@@ -115,7 +115,7 @@ void platform_init_enclave(struct enclave* enclave){
 }
 
 enclave_ret_code platform_create_enclave(struct enclave* enclave){
-  enclave->ped.use_scratch = 1;
+  enclave->ped.use_scratch = 0;
   int i;
   if(enclave->ped.use_scratch){
 

--- a/sm/platform/fu540/fu540_internal.c
+++ b/sm/platform/fu540/fu540_internal.c
@@ -113,8 +113,8 @@ void platform_create_enclave(struct enclave* enclave){
     scratch_init();
 
     /* Swap regions */
-    int old_epm_idx = get_enclave_region_index(enclave, REGION_EPM);
-    int new_idx = get_enclave_region_index(enclave, REGION_INVALID);
+    int old_epm_idx = get_enclave_region_index(enclave->eid, REGION_EPM);
+    int new_idx = get_enclave_region_index(enclave->eid, REGION_INVALID);
     //TODO safety check
     enclave->regions[new_idx].pmp_rid = scratch_rid;
     enclave->regions[new_idx].type = REGION_EPM;
@@ -167,7 +167,7 @@ void platform_destroy_enclave(struct enclave* enclave){
 
     /* Fix the enclave region info to no longer know about
        scratchpad */
-    int scratch_epm_idx = get_enclave_region_index(enclave, REGION_EPM);
+    int scratch_epm_idx = get_enclave_region_index(enclave->eid, REGION_EPM);
     enclave->regions[scratch_epm_idx].type = REGION_INVALID;
 
     /* Free the scratchpad */

--- a/sm/platform/fu540/fu540_internal.c
+++ b/sm/platform/fu540/fu540_internal.c
@@ -6,39 +6,90 @@
 #include <errno.h>
 #include "page.h"
 #include <string.h>
-void platform_init(struct platform_enclave_data_t* ped){
-  ped->num_ways = WM_NUM_WAYS/2;
-  ped->saved_mask = 0;
+
+void platform_init_global(){
+
+  waymask_init();
+
+  /* Lock off part of the L2 for use as scratchpad */
+
+
 }
 
-void platform_switch_to_enclave(struct platform_enclave_data_t* ped){
+void platform_init_enclave(struct platform_enclave_data* ped){
+  ped->num_ways = WM_NUM_WAYS/2;
+  ped->saved_mask = 0;
+  ped->scratchpad_mask = 0;
+}
+
+void platform_create_enclave(struct platform_enclave_data* ped){
+  /* TODO TMP way to try and get the scratchpad allocated */
+  waymask_allocate_scratchpad(&ped->scratchpad_mask);
+
+  /* Clear scratchpad for use */
+  unsigned int core = read_csr(mhartid) + 1;
+  waymask_apply_allocated_mask(ped->scratchpad_mask, core);
+
+  /* High ways to low ways */
+  /* TMP */
+  uintptr_t addr;
+  for(addr=L2_SCRATCH_START;
+      addr<(L2_SCRATCH_START + (8 * L2_WAY_SIZE));
+      addr+=sizeof(uintptr_t)){
+    *(uintptr_t*)addr = 0;
+  }
+  /* TMP turn off access */
+  _wm_assign_mask(0xFFFF,GET_CORE_DWAY(core));
+
+  ped->scratch_rid = 0;
+  /* TMP create pmp region */
+  if(pmp_region_init_atomic(L2_SCRATCH_START, 8*L2_WAY_SIZE, PMP_PRI_ANY, &ped->scratch_rid, 0)){
+    printm("FATAL CANNOT CREATE SCRATCH PMP\r\n");
+  }
+
+  printm("Created enclave, attempted to give it scratch\r\n");
+}
+
+void platform_destroy_enclave(struct platform_enclave_data* ped){
+  if(ped->scratchpad_mask != 0){
+    waymask_free_scratchpad(&ped->scratchpad_mask);
+  }
+  unsigned int core = read_csr(mhartid) + 1;
+  _wm_assign_mask(0xFFFFFFFF,GET_CORE_DWAY(core));
+}
+
+void platform_switch_to_enclave(struct platform_enclave_data* ped){
 
   // Each hart gets special access to some
-  unsigned int core = read_csr(mhartid) + 1;
+  //unsigned int core = read_csr(mhartid) + 1;
 
   /* Allocate ways, fresh every time we enter */
-  size_t remaining = waymask_allocate_ways(ped->num_ways,
-                                           core,
-                                           &ped->saved_mask);
+  /* size_t remaining = waymask_allocate_ways(ped->num_ways, */
+  /*                                          core, */
+  /*                                          &ped->saved_mask); */
 
   //printm("Chose ways: 0x%x, core 0x%x\r\n",ped->saved_mask, core);
 
 
   /* Assign the ways to all cores */
-  waymask_apply_allocated_mask(ped->saved_mask, core);
+  //  waymask_apply_allocated_mask(ped->saved_mask, core);
 
   /* Clear out these ways MUST first apply mask to other masters */
-  /* uintptr_t cycles1,cycles2; */
-  /* asm volatile ("rdcycle %0" : "=r" (cycles1)); */
-  waymask_clear_ways(ped->saved_mask, core);
-  /* asm volatile ("rdcycle %0" : "=r" (cycles2)); */
-  /* printm("Wipe cost %lx\r\n",cycles2-cycles1); */
+  //waymask_clear_ways(ped->saved_mask, core);
+
+
+  /* Setup PMP region for scratchpad */
+  if(ped->scratch_rid != 0){
+    pmp_set(ped->scratch_rid, PMP_ALL_PERM);
+    printm("Switching to an enclave with scratchpad access\r\n");
+  }
+
 
 }
 
-void platform_switch_from_enclave(struct platform_enclave_data_t* ped){
+void platform_switch_from_enclave(struct platform_enclave_data* ped){
   /* Free all our ways */
-  waymask_free_ways(ped->saved_mask);
+  //  waymask_free_ways(ped->saved_mask);
 
   /* We don't need to clean them, see docs */
 

--- a/sm/platform/fu540/waymasks.c
+++ b/sm/platform/fu540/waymasks.c
@@ -1,5 +1,16 @@
 #include "waymasks.h"
 
+void waymask_debug_printstatus(){
+  unsigned int hartid = read_csr(mhartid);
+  printm("mhartid: %x, coremasters: %x & %x\r\n",hartid, (hartid)*2, (hartid)*2 + 1);
+
+  unsigned int master;
+  for(master=0;master<WM_NUM_MASTERS;master++){
+    waymask_t* master_mask = WM_REG_ADDR(master);
+    printm("Master %x : %0.8x\r\n",master, *master_mask);
+  }
+}
+
 size_t waymask_allocate_ways(size_t n_ways, unsigned int target_hart,
                              waymask_t* mask){
 
@@ -26,7 +37,7 @@ int master_is_for_hart(unsigned int master, unsigned int hart){
 
 void waymask_apply_allocated_mask(waymask_t mask, unsigned int target_hart){
 
-  // Lockout/assign  masters from these ways
+  // Lockout/assign masters from these ways
   unsigned int master;
   for(master=0;master<WM_NUM_MASTERS;master++){
 
@@ -96,8 +107,8 @@ int _wm_lockout_ways(waymask_t mask, unsigned int master){
   // Supposedly this isn't allowed, we'll see what happens.
   // "At least one cache way must be enabled. "
   waymask_t* master_mask = WM_REG_ADDR(master);
-
-  *master_mask &= WM_FLIP_MASK(mask);
+  waymask_t current_mask = *master_mask;
+  *master_mask = current_mask & WM_FLIP_MASK(mask);
   return 0;
 }
 
@@ -136,11 +147,13 @@ void waymask_init(){
 void waymask_allocate_scratchpad(waymask_t* _mask){
 
   /* Avoid the 'special' ways we reserve for cores */
-  waymask_t mask = 0xFF00;
+  waymask_t mask = 0xF00 | 0x80 | 0x1000 | 0x2000 | 0x4000;
 
   /* tmp sanity check */
-  if( (allocated_ways & mask) != 0)
+  if( (allocated_ways & mask) != 0){
+    printm("Cannot allocate ways for scratchpad, in use!\r\n");
     return;
+  }
 
   scratchpad_allocated_ways = mask;
   allocated_ways |= scratchpad_allocated_ways;
@@ -155,16 +168,15 @@ void waymask_free_scratchpad(waymask_t* _mask){
     return;
   }
 
-  scratchpad_allocated_ways &= WM_FLIP_MASK(_mask);
-  allocated_ways &= WM_FLIP_MASK(_mask);
+  scratchpad_allocated_ways &= WM_FLIP_MASK(*_mask);
+  allocated_ways &= WM_FLIP_MASK(*_mask);
 
   *_mask = 0x0;
 
 }
 
 
-/* TODO, this isn't the right way to use the Zero Device, it should be
-   fine to set a bunch of ways and then write directly */
+/* TODO check this is the right way to clear */
 void waymask_clear_ways(waymask_t mask, unsigned int core){
 
   /* L2 Scratchpad (L2 Zero Device) allows us to write to non-memory

--- a/sm/platform/fu540/waymasks.c
+++ b/sm/platform/fu540/waymasks.c
@@ -144,7 +144,7 @@ void waymask_init(){
   scratchpad_allocated_ways = 0;
 }
 
-void waymask_allocate_scratchpad(waymask_t* _mask){
+void waymask_allocate_scratchpad(){
 
   /* Avoid the 'special' ways we reserve for cores */
   waymask_t mask = 0xF00 | 0x80 | 0x1000 | 0x2000 | 0x4000;
@@ -157,21 +157,12 @@ void waymask_allocate_scratchpad(waymask_t* _mask){
 
   scratchpad_allocated_ways = mask;
   allocated_ways |= scratchpad_allocated_ways;
-
-  *_mask = mask;
 }
 
-void waymask_free_scratchpad(waymask_t* _mask){
+void waymask_free_scratchpad(){
 
-  if((scratchpad_allocated_ways & *_mask) != *_mask){
-    //TODO fatal?
-    return;
-  }
-
-  scratchpad_allocated_ways &= WM_FLIP_MASK(*_mask);
-  allocated_ways &= WM_FLIP_MASK(*_mask);
-
-  *_mask = 0x0;
+  allocated_ways &= WM_FLIP_MASK(scratchpad_allocated_ways);
+  scratchpad_allocated_ways = 0;
 
 }
 

--- a/sm/platform/fu540/waymasks.h
+++ b/sm/platform/fu540/waymasks.h
@@ -125,8 +125,8 @@ void waymask_free_ways(waymask_t _mask);
 void waymask_init();
 void waymask_clear_ways(waymask_t mask, unsigned int core);
 
-void waymask_allocate_scratchpad(waymask_t* _mask);
-void waymask_free_scratchpad(waymask_t* _mask);
+void waymask_allocate_scratchpad();
+void waymask_free_scratchpad();
 
 /* Internals */
 int _wm_choose_ways_for_hart(size_t n_ways, waymask_t* _mask, unsigned int target_hart);

--- a/sm/platform/fu540/waymasks.h
+++ b/sm/platform/fu540/waymasks.h
@@ -50,6 +50,7 @@ waymask_t allocated_ways;
 
 /* PMP Region ID for the scratchpad */
 region_id scratch_rid;
+region_id l2_controller_rid;
 
 // Waymask master IDs
 #define WM_Hart_0_DCache_MMIO           0
@@ -103,7 +104,7 @@ region_id scratch_rid;
 
 // L2 Zero Device (Scratchpad) info
 #define L2_SCRATCH_START (0x0A000000)
-#define L2_SCRATCH_STOP  (0x0BFFFFFF)
+#define L2_SCRATCH_STOP  (0x0C000000)
 
 /* 2 MB */
 #define L2_SIZE (2*1024*1024)

--- a/sm/platform/fu540/waymasks.h
+++ b/sm/platform/fu540/waymasks.h
@@ -38,7 +38,14 @@
 
 typedef uint64_t waymask_t;
 
+/* Ways currently allocated to enclaves */
 waymask_t enclave_allocated_ways;
+
+/* Ways currently allocated to the scratchpad */
+waymask_t scratchpad_allocated_ways;
+
+/* All allocated ways, should be OR of above two */
+waymask_t allocated_ways;
 
 // Waymask master IDs
 #define WM_Hart_0_DCache_MMIO           0
@@ -78,7 +85,7 @@ waymask_t enclave_allocated_ways;
 #define WM_FLIP_MASK(mask) ((!mask) & WM_MASK)
 
 
-#define IS_WAY_ALLOCATED( waynum ) ( enclave_allocated_ways & (0x1 << waynum))
+#define IS_WAY_ALLOCATED( waynum ) ( allocated_ways & (0x1 << waynum))
 
 #define IS_MASTER_RUNNING_UNTRUSTED( master ) (/* TODO */ 0)
 
@@ -97,6 +104,7 @@ waymask_t enclave_allocated_ways;
 
 #define L2_NUM_SETS 512
 #define L2_SET_SIZE (L2_SIZE/L2_NUM_SETS)
+#define L2_WAY_SIZE (L2_SIZE/WM_NUM_WAYS)
 #define L2_LINE_SIZE (64)
 
 /* Interface */
@@ -106,6 +114,9 @@ void waymask_apply_allocated_mask(waymask_t mask, unsigned int target_hart);
 void waymask_free_ways(waymask_t _mask);
 void waymask_init();
 void waymask_clear_ways(waymask_t mask, unsigned int core);
+
+void waymask_allocate_scratchpad(waymask_t* _mask);
+void waymask_free_scratchpad(waymask_t* _mask);
 
 /* Internals */
 int _wm_choose_ways_for_hart(size_t n_ways, waymask_t* _mask, unsigned int target_hart);

--- a/sm/plugins/multimem.c
+++ b/sm/plugins/multimem.c
@@ -1,0 +1,30 @@
+#include "plugins/multimem.h"
+#include "sm.h"
+
+uintptr_t multimem_get_other_region_size(enclave_id eid)
+{
+  int mem_id = get_enclave_region_index(eid, REGION_OTHER);
+  printm("memid: %d\n",mem_id);
+  return get_enclave_region_size(eid, mem_id);
+}
+
+uintptr_t multimem_get_other_region_addr(enclave_id eid)
+{
+  int mem_id = get_enclave_region_index(eid, REGION_OTHER);
+  printm("memid: %d\n",mem_id);
+  return get_enclave_region_base(eid, mem_id);
+}
+
+uintptr_t do_sbi_multimem(enclave_id eid, uintptr_t call_id)
+{
+  switch(call_id)
+  {
+    case MULTIMEM_GET_OTHER_REGION_SIZE:
+      return multimem_get_other_region_size(eid);
+    case MULTIMEM_GET_OTHER_REGION_ADDR:
+      return multimem_get_other_region_addr(eid);
+    default:
+      return 0;
+  }
+  return 0;
+}

--- a/sm/plugins/multimem.c
+++ b/sm/plugins/multimem.c
@@ -4,14 +4,12 @@
 uintptr_t multimem_get_other_region_size(enclave_id eid)
 {
   int mem_id = get_enclave_region_index(eid, REGION_OTHER);
-  printm("memid: %d\n",mem_id);
   return get_enclave_region_size(eid, mem_id);
 }
 
 uintptr_t multimem_get_other_region_addr(enclave_id eid)
 {
   int mem_id = get_enclave_region_index(eid, REGION_OTHER);
-  printm("memid: %d\n",mem_id);
   return get_enclave_region_base(eid, mem_id);
 }
 

--- a/sm/plugins/multimem.h
+++ b/sm/plugins/multimem.h
@@ -1,0 +1,12 @@
+#ifndef __SM_MULTIMEM_H__
+#define __SM_MULTIMEM_H__
+
+#include "plugins/plugins.h"
+#include "enclave.h"
+
+#define MULTIMEM_GET_OTHER_REGION_SIZE 0x1
+#define MULTIMEM_GET_OTHER_REGION_ADDR 0x2
+
+uintptr_t do_sbi_multimem(enclave_id id, uintptr_t call_id);
+
+#endif

--- a/sm/plugins/plugins.c
+++ b/sm/plugins/plugins.c
@@ -15,7 +15,7 @@ call_plugin(
   switch(plugin_id) {
 #ifdef PLUGIN_ENABLE_MULTIMEM
     case PLUGIN_ID_MULTIMEM:
-      return do_sbi_multimem(plugin_id, call_id);
+      return do_sbi_multimem(id, call_id);
       break;
 #endif
     default:

--- a/sm/plugins/plugins.c
+++ b/sm/plugins/plugins.c
@@ -1,0 +1,26 @@
+#include "plugins/plugins.h"
+
+#ifdef PLUGIN_ENABLE_MULTIMEM
+  #include "plugins/multimem.c"
+#endif
+
+uintptr_t
+call_plugin(
+    enclave_id id,
+    uintptr_t plugin_id,
+    uintptr_t call_id,
+    uintptr_t arg0,
+    uintptr_t arg1)
+{
+  switch(plugin_id) {
+#ifdef PLUGIN_ENABLE_MULTIMEM
+    case PLUGIN_ID_MULTIMEM:
+      return do_sbi_multimem(plugin_id, call_id);
+      break;
+#endif
+    default:
+      // TOO fix it
+      return -ENOSYS;
+  }
+}
+

--- a/sm/plugins/plugins.h
+++ b/sm/plugins/plugins.h
@@ -1,15 +1,12 @@
 #ifndef __SM_PLUGINS_H__
 #define __SM_PLUGINS_H__
 
+#include "config.h"
 #include "sm.h"
 #include "enclave.h"
 
 /* PLUGIN IDs */
 #define PLUGIN_ID_MULTIMEM  0x1
-
-
-// TODO: move this to configure
-#define PLUGIN_ENABLE_MULTIMEM
 
 #ifdef PLUGIN_ENABLE_MULTIMEM
   #include "plugins/multimem.h"

--- a/sm/plugins/plugins.h
+++ b/sm/plugins/plugins.h
@@ -1,0 +1,27 @@
+#ifndef __SM_PLUGINS_H__
+#define __SM_PLUGINS_H__
+
+#include "sm.h"
+#include "enclave.h"
+
+/* PLUGIN IDs */
+#define PLUGIN_ID_MULTIMEM  0x1
+
+
+// TODO: move this to configure
+#define PLUGIN_ENABLE_MULTIMEM
+
+#ifdef PLUGIN_ENABLE_MULTIMEM
+  #include "plugins/multimem.h"
+#endif
+
+uintptr_t
+call_plugin(
+    enclave_id id,
+    uintptr_t plugin_id,
+    uintptr_t call_id,
+    uintptr_t arg0,
+    uintptr_t arg1
+    );
+
+#endif

--- a/sm/sm-sbi.c
+++ b/sm/sm-sbi.c
@@ -9,6 +9,7 @@
 #include "cpu.h"
 #include <errno.h>
 #include "platform.h"
+#include "plugins/plugins.h"
 
 uintptr_t mcall_sm_create_enclave(uintptr_t create_args)
 {
@@ -111,6 +112,15 @@ uintptr_t mcall_sm_random()
   /* Anyone may call this interface. */
 
   return platform_random();
+}
+
+uintptr_t mcall_sm_call_plugin(uintptr_t plugin_id, uintptr_t call_id, uintptr_t arg0, uintptr_t arg1)
+{
+  if(!cpu_is_enclave_context()) {
+    return ENCLAVE_SBI_PROHIBITED;
+  }
+
+  return call_plugin(cpu_get_enclave_id(), plugin_id, call_id, arg0, arg1);
 }
 
 /* TODO: this should be removed in the future. */

--- a/sm/sm-sbi.h
+++ b/sm/sm-sbi.h
@@ -21,4 +21,7 @@ uintptr_t mcall_sm_stop_enclave(uintptr_t* regs, unsigned long request);
 uintptr_t mcall_sm_resume_enclave(uintptr_t* regs, unsigned long eid);
 uintptr_t mcall_sm_attest_enclave(uintptr_t report, uintptr_t data, uintptr_t size);
 uintptr_t mcall_sm_random();
+
+uintptr_t mcall_sm_call_plugin(uintptr_t plugin_id, uintptr_t call_id, uintptr_t arg0, uintptr_t arg1);
+
 #endif

--- a/sm/sm.ac
+++ b/sm/sm.ac
@@ -1,3 +1,6 @@
 AC_ARG_WITH([target_platform], AS_HELP_STRING([--with-target-platform], [Set a specific platform for the sm to build with]),
   [AC_SUBST([TARGET_PLATFORM], $with_target_platform, [Set a specific platform for the sm to build with])],
   [AC_SUBST([TARGET_PLATFORM], default, [Set a specific platform for the sm to build with])])
+
+AC_ARG_ENABLE([sm_multimem], AS_HELP_STRING([--enable-sm-multimem], [Specify sm plugins to include]),
+  AC_DEFINE([PLUGIN_ENABLE_MULTIMEM],[],[Enable multimem plugin]),[])

--- a/sm/sm.c
+++ b/sm/sm.c
@@ -9,6 +9,7 @@
 #include "atomic.h"
 #include "crypto.h"
 #include "enclave.h"
+#include "platform.h"
 
 static int sm_init_done = 0;
 static int sm_region_id = 0, os_region_id = 0;
@@ -109,10 +110,16 @@ void sm_init(void)
       die("[SM] intolerable error - failed to initialize OS memory");
 
     sm_init_done = 1;
+
+
+    platform_init_global_once();
   }
 
   pmp_set(sm_region_id, PMP_NO_PERM);
   pmp_set(os_region_id, PMP_ALL_PERM);
+
+  /* Fire platform specific global init */
+  platform_init_global();
 
   // Copy the keypair from the root of trust
   sm_copy_key();

--- a/sm/sm.c
+++ b/sm/sm.c
@@ -112,14 +112,16 @@ void sm_init(void)
     sm_init_done = 1;
 
 
-    platform_init_global_once();
+    if(platform_init_global_once() != ENCLAVE_SUCCESS)
+      die("[SM] platform global init fatal error");
   }
 
   pmp_set(sm_region_id, PMP_NO_PERM);
   pmp_set(os_region_id, PMP_ALL_PERM);
 
   /* Fire platform specific global init */
-  platform_init_global();
+  if(platform_init_global() != ENCLAVE_SUCCESS)
+    die("[SM] platform global init fatal error");
 
   // Copy the keypair from the root of trust
   sm_copy_key();

--- a/sm/sm.h
+++ b/sm/sm.h
@@ -21,6 +21,7 @@
 #define SBI_SM_RESUME_ENCLAVE    107
 #define SBI_SM_RANDOM            108
 #define SBI_SM_EXIT_ENCLAVE     1101
+#define SBI_SM_CALL_PLUGIN      1000
 #define SBI_SM_NOT_IMPLEMENTED  1111
 
 /* error codes */

--- a/sm/sm.mk.in
+++ b/sm/sm.mk.in
@@ -18,6 +18,8 @@ sm_c_srcs = \
   ed25519/ge.c \
   ed25519/sc.c \
   platform/@TARGET_PLATFORM@/@TARGET_PLATFORM@.c \
+	plugins/plugins.c \
+# TODO: should be @PLUGIN_SOURSES@ \
 
 sm_asm_srcs =
 

--- a/sm/sm.mk.in
+++ b/sm/sm.mk.in
@@ -19,7 +19,6 @@ sm_c_srcs = \
   ed25519/sc.c \
   platform/@TARGET_PLATFORM@/@TARGET_PLATFORM@.c \
 	plugins/plugins.c \
-# TODO: should be @PLUGIN_SOURSES@ \
 
 sm_asm_srcs =
 

--- a/sm/tests/test_enclave.c
+++ b/sm/tests/test_enclave.c
@@ -108,12 +108,27 @@ static void test_get_enclave_region_after_init()
   }
 }
 
+static void test_get_enclave_region_index()
+{
+  enclave_id eid;
+  int memid;
+  enum enclave_region_type type;
+
+  enclave_init_metadata();
+
+  enclaves[0].regions[2].type = REGION_OTHER;
+  enclaves[0].regions[2].pmp_rid = 4;
+
+  assert_int_equal( get_enclave_region_index(0, REGION_OTHER), 2 );
+}
+
 int main()
 {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_is_create_args_valid),
     cmocka_unit_test(test_context_switch_to_enclave),
     cmocka_unit_test(test_get_enclave_region_after_init),
+    cmocka_unit_test(test_get_enclave_region_index),
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);

--- a/sm/tests/test_enclave.c
+++ b/sm/tests/test_enclave.c
@@ -77,11 +77,43 @@ static void test_context_switch_to_enclave()
 
 }
 
+static void test_get_enclave_region_after_init()
+{
+  enclave_id eid;
+  int memid;
+  enum enclave_region_type type;
+
+  enclave_init_metadata();
+
+  for (eid=0; eid < ENCL_MAX; eid++)
+  {
+    // testing get_enclave_region_index
+    assert_int_equal( get_enclave_region_index(eid, REGION_EPM), -1 );
+    assert_int_equal( get_enclave_region_index(eid, REGION_UTM), -1 );
+    assert_int_equal( get_enclave_region_index(eid, REGION_OTHER), -1 );
+    assert_int_equal( get_enclave_region_index(eid, REGION_INVALID), 0 );
+
+    // testing get_enclave_region_size
+    assert_int_equal( get_enclave_region_size(eid, REGION_EPM), 0 );
+    assert_int_equal( get_enclave_region_size(eid, REGION_UTM), 0 );
+    assert_int_equal( get_enclave_region_size(eid, REGION_OTHER), 0 );
+    assert_int_equal( get_enclave_region_size(eid, REGION_INVALID), 0 );
+
+    // testing get_enclave_region_base
+    assert_int_equal( get_enclave_region_base(eid, REGION_EPM), 0 );
+    assert_int_equal( get_enclave_region_base(eid, REGION_UTM), 0 );
+    assert_int_equal( get_enclave_region_base(eid, REGION_OTHER), 0 );
+    assert_int_equal( get_enclave_region_base(eid, REGION_INVALID), 0 );
+
+  }
+}
+
 int main()
 {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_is_create_args_valid),
     cmocka_unit_test(test_context_switch_to_enclave),
+    cmocka_unit_test(test_get_enclave_region_after_init),
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
FU540 plugin changes to add scratchpad support, fix cache part bugs, etc.
Added a generic multi-region interface for enclaves to allow for  >2 PMP logical regions.
Plugin for SBI to talk to these regions.