### PR TITLE
Undelegate all interrupts from enclave for now

### DIFF
--- a/machine/mtrap.c
+++ b/machine/mtrap.c
@@ -259,6 +259,8 @@ send_ipi:
       break;
     case SBI_SM_RESUME_ENCLAVE:
       retval = mcall_sm_resume_enclave(regs, arg0);
+      if (regs[0]) /* preserve a0 */
+        return;
       break;
     case SBI_SM_ATTEST_ENCLAVE:
       retval = mcall_sm_attest_enclave(arg0, arg1, arg2);

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -41,8 +41,11 @@ static inline enclave_ret_code context_switch_to_enclave(uintptr_t* regs,
                                                 int load_parameters){
 
   /* save host context */
-  swap_prev_state(&enclaves[eid].threads[0], regs);
+  swap_prev_state(&enclaves[eid].threads[0], regs, 1);
   swap_prev_mepc(&enclaves[eid].threads[0], read_csr(mepc));
+
+  uintptr_t interrupts = 0;
+  write_csr(mideleg, interrupts);
 
   if(load_parameters){
     // passing parameters for a first run
@@ -71,19 +74,6 @@ static inline enclave_ret_code context_switch_to_enclave(uintptr_t* regs,
 
   switch_vector_enclave();
 
-  hls_t* hls = HLS();
-  *hls->timecmp = getRTC() + ENCL_TIME_SLICE;
-
-  clear_csr(mip, MIP_MTIP);
-  clear_csr(mip, MIP_STIP);
-  clear_csr(mip, MIP_SSIP);
-  clear_csr(mip, MIP_SEIP);
-
-  set_csr(mie, MIP_MTIP);
-
-  uintptr_t interrupts = MIP_SSIP | MIP_SEIP;
-  write_csr(mideleg, interrupts);
-
   // set PMP
   osm_pmp_set(PMP_NO_PERM);
   int memid;
@@ -101,7 +91,8 @@ static inline enclave_ret_code context_switch_to_enclave(uintptr_t* regs,
 }
 
 static inline void context_switch_to_host(uintptr_t* encl_regs,
-    enclave_id eid){
+    enclave_id eid,
+    int return_on_resume){
 
   // set PMP
   int memid;
@@ -112,18 +103,14 @@ static inline void context_switch_to_host(uintptr_t* encl_regs,
   }
   osm_pmp_set(PMP_ALL_PERM);
 
-  /* restore host context */
-  swap_prev_state(&enclaves[eid].threads[0], encl_regs);
-  swap_prev_mepc(&enclaves[eid].threads[0], read_csr(mepc));
-
-  switch_vector_host();
-
   uintptr_t interrupts = MIP_SSIP | MIP_STIP | MIP_SEIP;
   write_csr(mideleg, interrupts);
 
-  // enable timer interrupt
-  clear_csr(mip, MIP_STIP);
-  clear_csr(mip, MIP_MTIP);
+  /* restore host context */
+  swap_prev_state(&enclaves[eid].threads[0], encl_regs, return_on_resume);
+  swap_prev_mepc(&enclaves[eid].threads[0], read_csr(mepc));
+
+  switch_vector_host();
 
   // Reconfigure platform specific defenses
   platform_switch_from_enclave(&(enclaves[eid]));
@@ -592,7 +579,7 @@ enclave_ret_code exit_enclave(uintptr_t* encl_regs, unsigned long retval, enclav
   if(!exitable)
     return ENCLAVE_NOT_RUNNING;
 
-  context_switch_to_host(encl_regs, eid);
+  context_switch_to_host(encl_regs, eid, 0);
 
   return ENCLAVE_SUCCESS;
 }
@@ -613,7 +600,7 @@ enclave_ret_code stop_enclave(uintptr_t* encl_regs, uint64_t request, enclave_id
   if(!stoppable)
     return ENCLAVE_NOT_RUNNING;
 
-  context_switch_to_host(encl_regs, eid);
+  context_switch_to_host(encl_regs, eid, request == STOP_EDGE_CALL_HOST);
 
   switch(request) {
   case(STOP_TIMER_INTERRUPT):

--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -112,6 +112,22 @@ static inline void context_switch_to_host(uintptr_t* encl_regs,
 
   switch_vector_host();
 
+  uintptr_t pending = read_csr(mip);
+
+  if (pending & MIP_MTIP) {
+    clear_csr(mip, MIP_MTIP);
+    set_csr(mip, MIP_STIP);
+  }
+  if (pending & MIP_MSIP) {
+    clear_csr(mip, MIP_MSIP);
+    set_csr(mip, MIP_SSIP);
+  }
+  if (pending & MIP_MEIP) {
+    clear_csr(mip, MIP_MEIP);
+    set_csr(mip, MIP_SEIP);
+  }
+
+
   // Reconfigure platform specific defenses
   platform_switch_from_enclave(&(enclaves[eid]));
 

--- a/sm/thread.c
+++ b/sm/thread.c
@@ -17,7 +17,7 @@ void switch_vector_host(){
 }
 
 uint64_t getRTC(){
-	return *mtime; 
+	return *mtime;
 }
 
 void swap_prev_mpp(struct thread_state* thread, uintptr_t* regs){
@@ -27,26 +27,28 @@ void swap_prev_mpp(struct thread_state* thread, uintptr_t* regs){
   int old_mpp = thread->prev_mpp;
   if(old_mpp < 0){
    //Old MPP bit isn't initialized!
-   old_mpp = curr_mstatus & 0x800;    
+   old_mpp = curr_mstatus & 0x800;
   }
   thread->prev_mpp = curr_mstatus & 0x800;
   int new_mstatus = (curr_mstatus & ~0x800) | old_mpp;
-  write_csr(mstatus, new_mstatus); 
+  write_csr(mstatus, new_mstatus);
 }
 
 /* Swaps the entire s-mode visible state, general registers and then csrs */
-void swap_prev_state(struct thread_state* thread, uintptr_t* regs)
+void swap_prev_state(struct thread_state* thread, uintptr_t* regs, int return_on_resume)
 {
   int i;
 
   uintptr_t* prev = (uintptr_t*) &thread->prev_state;
-  for(i=1; i<32; i++)
+  for(i=0; i<32; i++)
   {
     /* swap state */
     uintptr_t tmp = prev[i];
     prev[i] = regs[i];
     regs[i] = tmp;
   }
+
+  prev[0] = !return_on_resume;
 
   swap_prev_smode_csrs(thread);
 
@@ -100,7 +102,7 @@ void clean_state(struct thread_state* state){
     prev[i] = 0;
   }
 
-  state->prev_mpp = -1; // 0x800;   
+  state->prev_mpp = -1; // 0x800;
   clean_smode_csrs(state);
 }
 

--- a/sm/thread.h
+++ b/sm/thread.h
@@ -67,19 +67,19 @@ struct csrs
 /* enclave thread state */
 struct thread_state
 {
-  int prev_mpp; 
+  int prev_mpp;
   uintptr_t prev_mepc;
   struct csrs prev_csrs;
   struct ctx prev_state;
 };
 
 /* swap previous and current thread states */
-void swap_prev_state(struct thread_state* state, uintptr_t* regs);
+void swap_prev_state(struct thread_state* state, uintptr_t* regs, int return_on_resume);
 void swap_prev_mepc(struct thread_state* state, uintptr_t mepc);
 void swap_prev_smode_csrs(struct thread_state* thread);
-void swap_prev_mpp(struct thread_state* thread, uintptr_t* regs); 
+void swap_prev_mpp(struct thread_state* thread, uintptr_t* regs);
 
-uint64_t getRTC(); 
+uint64_t getRTC();
 void switch_vector_enclave();
 void switch_vector_host();
 extern void trap_vector_enclave();

--- a/sm/trap.S
+++ b/sm/trap.S
@@ -2,16 +2,11 @@
 #include "bits.h"
 #include "config.h"
 
-
-#define BAD_TRAP_VECTOR 0
-#define TRAP_FROM_MACHINE_MODE_VECTOR 13
-#define HANDLE_IPI_PMP_VECTOR 16
-
   .data
   .align 6
-
 enclave_trap_table:
-  .word bad_trap
+#define BAD_TRAP_VECTOR 0
+  .word pmp_trap
   .word pmp_trap
   .word illegal_insn_trap
   .word bad_trap
@@ -20,21 +15,24 @@ enclave_trap_table:
   .word misaligned_store_trap
   .word pmp_trap
   .word bad_trap
-  .word mcall_trap_enclave // 9 --> ECALL from S-mode
+  .word mcall_trap // 9 --> ECALL from S-mode
   .word bad_trap
   .word bad_trap
   .word bad_trap
+#define TRAP_FROM_MACHINE_MODE_VECTOR 13
+  .word __trap_from_machine_mode
+  .word pmp_trap
+  .word pmp_trap
+#ifdef SM_ENABLED
+# define HANDLE_IPI_PMP_VECTOR 16
+  .word handle_pmp_ipi
+#endif
+
   .option norvc
   .section .text.init,"ax",@progbits
   .globl enclave_trap_table
   .globl trap_vector_enclave
 
-.Lmret:
-  # Go back whence we came.
-  LOAD a0, 10*REGBYTES(sp)
-  LOAD a1, 11*REGBYTES(sp)
-  csrrw sp, mscratch, sp # sp <- mscratch 
-  mret
 
 trap_vector_enclave:
   csrrw sp, mscratch, sp
@@ -46,51 +44,20 @@ trap_vector_enclave:
 
   bgez a1, .Lhandle_trap_in_machine_mode
 
-  # This is an interrupt.  Discard the mcause MSB and decode the rest.
-  sll a1, a1, 1
-
-  # Is it a machine timer interrupt?
-  li a0, IRQ_M_TIMER * 2
-  bne a0, a1, .Lmret
-
-  # Yes.  Simply clear MSIE and raise SSIP.
-  li a0, MIP_MTIP
-  csrc mie, a0
-  
-  li a0, MIP_MTIP
-  csrc mip, a0
-
-  j .Lhandle_timer_int_machine_mode 
-
-.Lhandle_timer_int_machine_mode:
-  li a1, 9 # set mcause <- 9 (mcall_trap)
-
   STORE ra, 1*REGBYTES(sp)
   STORE gp, 3*REGBYTES(sp)
   STORE tp, 4*REGBYTES(sp)
   STORE t0, 5*REGBYTES(sp)
-1:auipc t0, %pcrel_hi(enclave_trap_table)  # t0 <- %hi(trap_table)
   STORE t1, 6*REGBYTES(sp)
-  sll t1, a1, 2                    # t1 <- mcause << 2
   STORE t2, 7*REGBYTES(sp)
-  add t1, t0, t1                   # t1 <- %hi(trap_table)[mcause]
   STORE s0, 8*REGBYTES(sp)
-  LWU t1, %pcrel_lo(1b)(t1)         # t1 <- trap_table[mcause]
   STORE s1, 9*REGBYTES(sp)
- 
-  li a0, 0  # a0 <- REQUEST = TIMER_INTERRUPT
-  STORE x0, 10*REGBYTES(sp) 
-
-  mv a0, sp                        # a0 <- regs  
   STORE a2,12*REGBYTES(sp)
-  csrr a2, mepc                    # a2 <- mepc
   STORE a3,13*REGBYTES(sp)
-  csrrw t0, mscratch, x0           # t0 <- user sp
   STORE a4,14*REGBYTES(sp)
   STORE a5,15*REGBYTES(sp)
   STORE a6,16*REGBYTES(sp)
   STORE a7,17*REGBYTES(sp)
-
   STORE s2,18*REGBYTES(sp)
   STORE s3,19*REGBYTES(sp)
   STORE s4,20*REGBYTES(sp)
@@ -105,17 +72,68 @@ trap_vector_enclave:
   STORE t4,29*REGBYTES(sp)
   STORE t5,30*REGBYTES(sp)
   STORE t6,31*REGBYTES(sp)
+  csrrw t0, mscratch, x0           # t0 <- user sp
   STORE t0, 2*REGBYTES(sp)         # sp
 
+  # call mcall_sm_stop_enclave
+  mv a0, sp
+  li a1, 0
+  call mcall_sm_stop_enclave
+  li a0, 2
+  STORE a0, 10*REGBYTES(sp)
 
-  li a7, 106 #set n <- SBI_SM_STOP_ENCLAVE
-  STORE a7, (17)*REGBYTES(sp)
-
-  jalr t1  
-  
   j restore_mscratch
-  
 
+############ Below are exact copy of mentry.S
+.Lmret:
+  # Go back whence we came.
+  LOAD a0, 10*REGBYTES(sp)
+  LOAD a1, 11*REGBYTES(sp)
+  csrrw sp, mscratch, sp # sp <- mscratch
+  mret
+
+.Lhandle_ipi_in_machine_mode:
+  # Is it an IPI?
+  # li a0, IRQ_M_SOFT * 2
+  # bne a0, a1, .Lbad_trap
+
+  # Yes.  First, clear the MIPI bit.
+  LOAD a0, MENTRY_IPI_OFFSET(sp)
+  sw x0, (a0)
+  fence
+
+  # Now, decode the cause(s).
+#ifdef __riscv_atomic
+  addi a0, sp, MENTRY_IPI_PENDING_OFFSET
+  amoswap.w a0, x0, (a0)
+#else
+  lw a0, MENTRY_IPI_PENDING_OFFSET(a0)
+  sw x0, MENTRY_IPI_PENDING_OFFSET(a0)
+#endif
+
+  and a1, a0, IPI_SOFT
+  beqz a1, 1f
+  csrs mip, MIP_SSIP
+1:
+  andi a1, a0, IPI_FENCE_I
+  beqz a1, 1f
+  fence.i
+1:
+  andi a1, a0, IPI_SFENCE_VMA
+  beqz a1, 1f
+  sfence.vma
+1:
+  andi a1, a0, IPI_HALT
+  beqz a1, 1f
+  wfi
+  j 1b
+#ifdef SM_ENABLED
+1:
+  andi a1, a0, IPI_PMP
+  bnez a1, .Lipi_pmp
+#endif
+1:
+  j .Lmret
 
 .Lhandle_trap_in_machine_mode:
   # Preserve the registers.  Compute the address of the trap handler.
@@ -173,7 +191,6 @@ restore_mscratch:
   csrw mscratch, sp
 
 restore_regs:
-
   # Restore all of the registers.
   LOAD ra, 1*REGBYTES(sp)
   LOAD gp, 3*REGBYTES(sp)
@@ -225,15 +242,6 @@ restore_regs:
 .Lbad_trap:
   li a1, BAD_TRAP_VECTOR
   j .Lhandle_trap_in_machine_mode
-
-__redirect_trap:
-  # reset sp to top of M-mode stack
-  li t0, MACHINE_STACK_SIZE
-  add sp, sp, t0
-  neg t0, t0
-  and sp, sp, t0
-  addi sp, sp, -MENTRY_FRAME_SIZE
-  j restore_mscratch
 
 __trap_from_machine_mode:
   jal trap_from_machine_mode


### PR DESCRIPTION
- Delegating interrupt to enclave is unstable and vulnerable for now
  because the SM does not explicitly manage ownership of the interrupts.
  Plus, enclave can arbitrarily drop the OS's software/external
  interrupts which is a denial of service in some sense.
- Bug fixed for the interrupt handling in M-mode:
  Because of the interrupt undelegation, M-mode writes 0 to mideleg when
  before it restores host's S-mode CSRs. This resulted in automatically
  overwriting host's sip and sie to 0, according to the ISA specification.
  When we write to mideleg, we take extra care on the order of
  execution.
- Preserving a0 on resume for interrupts
  Now, as there will be two kinds of stop_enclave: (1) interrupt, and
  (2) edge call. If it is (1), we need to fully recover enclave's state
  including the return register (a0). This has been implemented simply
  by using the zero register slot of the context saved in the stack.