### PR TITLE
Set RUST_OPT_FLAG correctly

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -198,8 +198,8 @@ $(2)_crate_libs := $$(addprefix lib, $$(addsuffix .a, $$($(2)_crates)))
 
 .PHONY: $$($(2)_crates)
 
-ifeq (debug,release)
-	RUST_OPT_FLAG := --release
+ifeq (@RUST_OPT@,release)
+  RUST_OPT_FLAG := --release
 endif
 
 $$($(2)_provides_libs) : lib$(1).a


### PR DESCRIPTION
Hi,
I've got the following failure while building keystone with the Rust SM.
```
cp sm-rs/riscv64gc-unknown-none-elfhf/release/libsm_rs.a libsm-rs.a
cp: cannot stat 'sm-rs/riscv64gc-unknown-none-elfhf/release/libsm_rs.a': No such file or directory
Makefile:341: recipe for target 'libsm-rs.a' failed
```
It seems that RUST_OPT_FLAG isn't set correctly because of the lines at riscv-pk/Makefile.in:199

```
.PHONY: $$($(2)_crates)

ifeq (debug,release)
	RUST_OPT_FLAG := --release
endif
```
Looks some unintentional change happens to the ifeq line. Another problem is that the leading TAB of the next line will silently prevent from setting RUST_OPT_FLAG when this is just after the .PHONY rule. Although I can't find this behavior in the gnu make manual, I've confirmed that gnu make 4.1 and 4.2.1 echo nothing for the toy makefile below:
```
.PHONY: foo

	RUST_OPT_FLAG := --release

all:
	@echo $(RUST_OPT_FLAG)
```
PR is tested with both "cmake .. -DUSE_RUST_SM=y" and "cmake .. -DUSE_RUST_SM=y -DSM_CONFIGURE_ARGS="--enable-opt=0".