### PR TITLE
Properly unset PMP registers when deinitializing a failed enclave

### DIFF
--- a/sm/enclave.c
+++ b/sm/enclave.c
@@ -461,7 +461,7 @@ enclave_ret_code create_enclave(struct keystone_sbi_create create_args)
      it may modify the enclave struct */
   ret = platform_create_enclave(&enclaves[eid]);
   if(ret != ENCLAVE_SUCCESS)
-    goto free_shared_region;
+    goto unset_region;
 
   /* Validate memory, prepare hash and signature for attestation */
   spinlock_lock(&encl_lock); // FIXME This should error for second enter.
@@ -481,6 +481,8 @@ enclave_ret_code create_enclave(struct keystone_sbi_create create_args)
 
 free_platform:
   platform_destroy_enclave(&enclaves[eid]);
+unset_region:
+  pmp_unset_global(region);
 free_shared_region:
   pmp_region_free_atomic(shared_region);
 free_region:

--- a/sm_rs/enclave.rs
+++ b/sm_rs/enclave.rs
@@ -870,13 +870,16 @@ pub mod sbi_functions {
 
     #[no_mangle]
     pub extern "C" fn destroy_enclave(eid: enclave_id) -> enclave_ret_code {
-        ENCLAVES[eid as usize]
-            .lock()
-            .take()
-            .ok_or(encl_ret!(NOT_DESTROYABLE))
-            .and_then(|mut e| super::destroy_enclave(&mut e))
-            .err()
-            .unwrap_or(encl_ret!(SUCCESS))
+        if let Some(enc) = ENCLAVES.get(eid as usize) {
+            enc.lock()
+                .take()
+                .ok_or(encl_ret!(NOT_DESTROYABLE))
+                .and_then(|mut e| super::destroy_enclave(&mut e))
+                .err()
+                .unwrap_or(encl_ret!(SUCCESS))
+        } else {
+            encl_ret!(INVALID_ID)
+        }
     }
 }
 

--- a/sm_rs/pmp.rs
+++ b/sm_rs/pmp.rs
@@ -11,6 +11,8 @@ pub enum Priority {
 
 pub struct PmpRegion {
     region: c_int,
+    should_unset: bool,
+    should_unset_global: bool,
     should_free: bool,
 }
 
@@ -27,6 +29,8 @@ impl PmpRegion {
 
         Ok(Self {
             region,
+            should_unset: false,
+            should_unset_global: false,
             should_free: true,
         })
     }
@@ -50,6 +54,7 @@ impl PmpRegion {
     pub fn unset_perm(&mut self) -> Result<(), c_int> {
         let err = unsafe { pmp_unset(self.region) };
         if err == 0 {
+            self.should_unset = true;
             Ok(())
         } else {
             Err(err)
@@ -59,6 +64,7 @@ impl PmpRegion {
     pub fn set_global(&mut self, perm: u8) -> Result<(), c_int> {
         let err = unsafe { pmp_set_global(self.region, perm) };
         if err == 0 {
+            self.should_unset_global = true;
             Ok(())
         } else {
             Err(err)
@@ -89,6 +95,12 @@ impl Drop for PmpRegion {
     fn drop(&mut self) {
         if self.should_free {
             unsafe {
+                if self.should_unset {
+                    self.unset_perm();
+                }
+                if self.should_unset_global {
+                    self.unset_global();
+                }
                 pmp_region_free_atomic(self.region);
             }
         }


### PR DESCRIPTION
This fixes https://github.com/keystone-enclave/keystone/issues/169, which allows #54 to properly recover from an error during MPRV copy!