### PR TITLE
platform_random: use Middle Square Weyl Sequence algorithm for better fake RNG

### DIFF
--- a/sm/platform/default/default.c
+++ b/sm/platform/default/default.c
@@ -31,7 +31,14 @@ void platform_switch_from_enclave(struct enclave* enclave){
 
 uint64_t platform_random(){
 #pragma message("Platform has no entropy source, this is unsafe. TEST ONLY")
+  static uint64_t w = 0, s = 0xb5ad4eceda1ce2a9;
+
   unsigned long cycles;
   asm volatile ("rdcycle %0" : "=r" (cycles));
-  return cycles;
+  
+  // from Middle Square Weyl Sequence algorithm
+  uint64_t x = cycles;
+  x *= x; 
+  x += (w += s); 
+  return (x>>32) | (x<<32);
 }

--- a/sm_rs/platform/default/default.c
+++ b/sm_rs/platform/default/default.c
@@ -31,7 +31,14 @@ void platform_switch_from_enclave(struct enclave* enclave){
 
 uint64_t platform_random(){
 #pragma message("Platform has no entropy source, this is unsafe. TEST ONLY")
+  static uint64_t w = 0, s = 0xb5ad4eceda1ce2a9;
+
   unsigned long cycles;
   asm volatile ("rdcycle %0" : "=r" (cycles));
-  return cycles;
+  
+  // from Middle Square Weyl Sequence algorithm
+  uint64_t x = cycles;
+  x *= x; 
+  x += (w += s); 
+  return (x>>32) | (x<<32);
 }


### PR DESCRIPTION
Running the DRAM encryption code, which relies on SBI randomness for a coprime number computation, I realized that the loop was running forever because `platform_random` was always returning an even number. I suppose it was just lucky that there were always an even number of instructions in between calls.

Anyway, this PR runs the `rdcycle` output through a single pass of this PRNG for better bit shuffling.