### PR TITLE
Fix Rust build for latest nightly

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,6 @@
 [build]
 target = "riscv64gc-unknown-none-elfhf.json"
+rustflags = ["-Cbitcode-in-rlib=yes"]
 
 [target.riscv64gc-unknown-linux-gnuhf]
 runner = "./scripts/qemu-riscv64"


### PR DESCRIPTION
Current nightly complains that implicit `-Cbitcode-in-rlib=no` is incompatible with LTO