### PR TITLE
More robust fix to Rust build, switch cargo xrustc to xbuild

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,5 @@
 [build]
 target = "riscv64gc-unknown-none-elfhf.json"
-rustflags = ["-Cbitcode-in-rlib=yes"]
 
 [target.riscv64gc-unknown-linux-gnuhf]
 runner = "./scripts/qemu-riscv64"

--- a/Makefile.in
+++ b/Makefile.in
@@ -212,7 +212,9 @@ $$($(2)_crate_libs) : lib%.a : %
 	$(eval RUST_TARGET_NAME := $(shell basename $(RUST_TARGET) .json))
 	cd $(src_dir)/$(2) ;\
 	  export CFLAGS=$(PLATFORM_FLAG) ;\
-	  cargo +nightly xrustc --verbose --target $(RUST_TARGET) $(RUST_OPT_FLAG) --target-dir $(_PWD)/$$< -- -Clto
+	  export CARGO_PROFILE_RELEASE_LTO=true ;\
+	  export CARGO_PROFILE_DEBUG_LTO=true ;\
+	  cargo +nightly xbuild --verbose --target $(RUST_TARGET) $(RUST_OPT_FLAG) --target-dir $(_PWD)/$$<
 	cp $$</$(RUST_TARGET_NAME)/@RUST_OPT@/lib$$(subst -,_,$$<).a $$@
 
 $(2)_junk += $$($(2)_c_objs) $$($(2)_c_deps) $$($(2)_asm_objs)


### PR DESCRIPTION
This moves off of the brittle `cargo xrustc` command, which invokes compiler arguments directly, to using cargo's environment variables. It all boils down to LTO, which we want to enable only for certain targets.