### PR TITLE
Remove usage of 'master' in the context of 'master/slave' 

### DIFF
--- a/bbl/bbl.c
+++ b/bbl/bbl.c
@@ -14,7 +14,7 @@ static uintptr_t dtb_output()
 {
   extern char _payload_end;
   uintptr_t end = (uintptr_t) &_payload_end;
-  return (end + MEGAPAGE_SIZE - 1) / MEGAPAGE_SIZE * MEGAPAGE_SIZE;
+  return (((end + MEGAPAGE_SIZE - 1) / MEGAPAGE_SIZE) + 16) * MEGAPAGE_SIZE;
 }
 
 static void filter_dtb(uintptr_t source)
@@ -22,6 +22,7 @@ static void filter_dtb(uintptr_t source)
   uintptr_t dest = dtb_output();
   uint32_t size = fdt_size(source);
   memcpy((void*)dest, (void*)source, size);
+  printm("Relocated DTB from %lx to %lx\n", source, dest);
 
   // Remove information from the chained FDT
   filter_harts(dest, &disabled_hart_mask);

--- a/sm/platform/fu540/waymasks.h
+++ b/sm/platform/fu540/waymasks.h
@@ -5,21 +5,22 @@
 #include <stddef.h>
 #include "pmp.h"
 
-#define WM_NUM_MASTERS 21
+/* Note: FU540 documentation refers to "masters" rather than controllers */
+#define WM_NUM_CONTROLLERS 21
 #define WM_NUM_WAYS 16
 #define WM_NUM_HARTS 4
 
 #define WM_MIN_FREE_WAY WM_NUM_HARTS
-#define WM_MAX_FREE_WAY WM_NUM_WAYS-2 /* We allocate 1 way for all non hart masters */
+#define WM_MAX_FREE_WAY WM_NUM_WAYS-2 /* We allocate 1 way for all non hart controllers */
 
 /* Waymasking is part of the dynamic way-allocation system.
  *
  * A Way is in one of 3 global logical states (W_n):
- *  - Free (in use on any master using untrusted code) - F
+ *  - Free (in use on any controller using untrusted code) - F
  *  - Free-reserved (Free, but may not be allocated in all circumstances) - FR
  *  - Allocated (in use for one specific enclave) - A
  *
- * A way is in one of 2 states on each master (MW_n):
+ * A way is in one of 2 states on each controller (MW_n):
  *  - Granted (1 in mask, available to be used) - G
  *  - Locked (0 in mask, not available to be used) - L
  *
@@ -28,7 +29,7 @@
 
 /* Legal allocations
  ********************
- * Way  0    : (FR) All non-hart masters, all untrusted execution
+ * Way  0    : (FR) All non-hart controllers, all untrusted execution
  * Ways 1-C  : (FR/A) Hart N MAY always has way N, untrusted or enclave mode.
  *                    Enclave mode is not required to use Way N.
  * Ways C-M  : (F/A) Free or allocated to an enclave
@@ -52,7 +53,7 @@ waymask_t allocated_ways;
 region_id scratch_rid;
 region_id l2_controller_rid;
 
-// Waymask master IDs
+// Waymask controller IDs
 #define WM_Hart_0_DCache_MMIO           0
 #define WM_Hart_0_ICache                1
 #define WM_Hart_1_DCache                2
@@ -94,7 +95,7 @@ region_id l2_controller_rid;
 
 #define IS_WAY_ALLOCATED( waynum ) ( allocated_ways & (0x1 << waynum))
 
-#define IS_MASTER_RUNNING_UNTRUSTED( master ) (/* TODO */ 0)
+#define IS_CONTROLLER_RUNNING_UNTRUSTED( controller ) (/* TODO */ 0)
 
 //NOTE: We ignore hart1, its a special hart and is disabled. There is
 //no hart0?
@@ -130,9 +131,9 @@ void waymask_free_scratchpad();
 
 /* Internals */
 int _wm_choose_ways_for_hart(size_t n_ways, waymask_t* _mask, unsigned int target_hart);
-int _wm_lockout_ways(waymask_t mask, unsigned int master);
+int _wm_lockout_ways(waymask_t mask, unsigned int controller);
 int _wm_grant_ways(waymask_t mask, unsigned int hart);
-int _wm_assign_mask(waymask_t mask, unsigned int master);
+int _wm_assign_mask(waymask_t mask, unsigned int controller);
 void waymask_debug_printstatus();
 
 #endif /* _WAYMASKS_H_ */

--- a/sm_rs/platform/fu540/fu540_internal.c
+++ b/sm_rs/platform/fu540/fu540_internal.c
@@ -40,16 +40,16 @@ enclave_ret_code scratch_init(){
   uintptr_t addr;
 
   addr = scratch_start;
-  /* We will be directly setting the master d$ mask to avoid any cache
+  /* We will be directly setting the controller d$ mask to avoid any cache
      pollution issues */
-  waymask_t* master_mask = WM_REG_ADDR(core*2);
+  waymask_t* controller_mask = WM_REG_ADDR(core*2);
   /* Go through the mask one way at a time to control the allocations */
   for(tmp_mask=0x80;
       tmp_mask <= scratchpad_allocated_ways;
       tmp_mask = tmp_mask << 1){
     uintptr_t way_end  = addr + L2_WAY_SIZE;
     /* Assign a temporary mask of 1 way to the d$ */
-    *master_mask = tmp_mask;
+    *controller_mask = tmp_mask;
     /* Write a known value to every L2_LINE_SIZE offset */
     for(;
         addr < way_end;
@@ -57,10 +57,10 @@ enclave_ret_code scratch_init(){
       *(uintptr_t*)addr = 64;
     }
     /* Disable as soon as possible */
-    *master_mask = invert_mask;
+    *controller_mask = invert_mask;
   }
 
-  /* At this point, no master has waymasks for the scratchpad ways,
+  /* At this point, no controller has waymasks for the scratchpad ways,
      and all scratchpad addresses have L2 lines */
 
   /* We try and check it now, any error SHOULD be immediately detectable. */
@@ -203,7 +203,7 @@ void platform_switch_to_enclave(struct enclave* enclave){
     /* Assign the ways to all cores */
     waymask_apply_allocated_mask(ped->saved_mask, core);
 
-    /* Clear out these ways MUST first apply mask to other masters */
+    /* Clear out these ways MUST first apply mask to other controllers */
     waymask_clear_ways(ped->saved_mask, core);
   }
 

--- a/sm_rs/platform/fu540/waymasks.h
+++ b/sm_rs/platform/fu540/waymasks.h
@@ -5,21 +5,22 @@
 #include <stddef.h>
 #include "pmp.h"
 
-#define WM_NUM_MASTERS 21
+/* Note: FU540 documentation refers to "masters" rather than controllers */
+#define WM_NUM_CONTROLLERS 21
 #define WM_NUM_WAYS 16
 #define WM_NUM_HARTS 4
 
 #define WM_MIN_FREE_WAY WM_NUM_HARTS
-#define WM_MAX_FREE_WAY WM_NUM_WAYS-2 /* We allocate 1 way for all non hart masters */
+#define WM_MAX_FREE_WAY WM_NUM_WAYS-2 /* We allocate 1 way for all non hart controllers */
 
 /* Waymasking is part of the dynamic way-allocation system.
  *
  * A Way is in one of 3 global logical states (W_n):
- *  - Free (in use on any master using untrusted code) - F
+ *  - Free (in use on any controller using untrusted code) - F
  *  - Free-reserved (Free, but may not be allocated in all circumstances) - FR
  *  - Allocated (in use for one specific enclave) - A
  *
- * A way is in one of 2 states on each master (MW_n):
+ * A way is in one of 2 states on each controller (MW_n):
  *  - Granted (1 in mask, available to be used) - G
  *  - Locked (0 in mask, not available to be used) - L
  *
@@ -28,7 +29,7 @@
 
 /* Legal allocations
  ********************
- * Way  0    : (FR) All non-hart masters, all untrusted execution
+ * Way  0    : (FR) All non-hart controllers, all untrusted execution
  * Ways 1-C  : (FR/A) Hart N MAY always has way N, untrusted or enclave mode.
  *                    Enclave mode is not required to use Way N.
  * Ways C-M  : (F/A) Free or allocated to an enclave
@@ -52,7 +53,7 @@ waymask_t allocated_ways;
 region_id scratch_rid;
 region_id l2_controller_rid;
 
-// Waymask master IDs
+// Waymask controller IDs
 #define WM_Hart_0_DCache_MMIO           0
 #define WM_Hart_0_ICache                1
 #define WM_Hart_1_DCache                2
@@ -94,7 +95,7 @@ region_id l2_controller_rid;
 
 #define IS_WAY_ALLOCATED( waynum ) ( allocated_ways & (0x1 << waynum))
 
-#define IS_MASTER_RUNNING_UNTRUSTED( master ) (/* TODO */ 0)
+#define IS_CONTROLLER_RUNNING_UNTRUSTED( controller ) (/* TODO */ 0)
 
 //NOTE: We ignore hart1, its a special hart and is disabled. There is
 //no hart0?
@@ -130,9 +131,9 @@ void waymask_free_scratchpad();
 
 /* Internals */
 int _wm_choose_ways_for_hart(size_t n_ways, waymask_t* _mask, unsigned int target_hart);
-int _wm_lockout_ways(waymask_t mask, unsigned int master);
+int _wm_lockout_ways(waymask_t mask, unsigned int controller);
 int _wm_grant_ways(waymask_t mask, unsigned int hart);
-int _wm_assign_mask(waymask_t mask, unsigned int master);
+int _wm_assign_mask(waymask_t mask, unsigned int controller);
 void waymask_debug_printstatus();
 
 #endif /* _WAYMASKS_H_ */


### PR DESCRIPTION
This has been replaced with 'controller' for the relevant contexts around bus device relationships.